### PR TITLE
Added print output to widgets

### DIFF
--- a/test/tangy-text-widget_test.html
+++ b/test/tangy-text-widget_test.html
@@ -80,7 +80,7 @@
         test('should show print view', () => {
           const element = fixture('ResumeFixture')
           element.mode = 'MODE_PRINT'
-          assert.equal(element.shadowRoot.querySelector('#print-container').innerText.includes('Variable name'), true)
+          element.shadowRoot.querySelector('#print-container').innerText.includes('Prompt')
         })
       })
 

--- a/widget/tangy-checkboxes-widget.js
+++ b/widget/tangy-checkboxes-widget.js
@@ -1,14 +1,13 @@
-import '@polymer/paper-card/paper-card.js'
-import '@polymer/paper-button/paper-button.js'
-import 'tangy-form/tangy-form.js'
-import 'tangy-form/input/tangy-checkboxes.js'
-import 'tangy-form/input/tangy-input.js'
-import { TangyBaseWidget } from '../tangy-base-widget.js'
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
+import 'tangy-form/tangy-form.js';
+import 'tangy-form/input/tangy-checkboxes.js';
+import 'tangy-form/input/tangy-input.js';
+import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyCheckboxesWidget extends TangyBaseWidget {
-
   get claimElement() {
-    return 'tangy-checkboxes'
+    return 'tangy-checkboxes';
   }
 
   get defaultConfig() {
@@ -20,22 +19,24 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
       disabled: false,
       hidden: false,
       tangyIf: ''
-    }
+    };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
-    return {...config, ...element.getProps(),
+    return {
+      ...config,
+      ...element.getProps(),
       options: [...element.querySelectorAll('option')].map(option => {
         return {
           value: option.getAttribute('value'),
           label: option.innerHTML
-        }
+        };
       }),
       tangyIf: element.hasAttribute('tangy-if')
         ? element.getAttribute('tangy-if')
         : ''
-    }
+    };
   }
 
   downcast(config) {
@@ -47,16 +48,40 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
       >
-       ${config.options.map(option => `
+       ${config.options
+         .map(
+           option => `
         <option value="${option.value}">${option.label}</option>
-      `).join('')}
+      `
+         )
+         .join('')}
       </tangy-checkboxes>
-    `
+    `;
   }
-
+  renderPrint(config) {
+    let keyValuePairs = '';
+    config.options.map(option => {
+      keyValuePairs += `<li>${option.value}: ${option.label}</li>`;
+    });
+    return `
+   
+    <table>
+      <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
+      <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+      <tr><td><strong>Options:</strong></td><td><ul>${keyValuePairs}</ul></td></tr>
+    </table>
+    <hr/>
+    `;
+  }
   renderInfo(config) {
-    return `<div class="element-header"><mwc-icon>check_box_outline_blank</mwc-icon><div id="element-name">${config.name}</div></div>
-    ${config.options.length > 0 ? this.downcast(config) : ''}`
+    return `<div class="element-header"><mwc-icon>check_box_outline_blank</mwc-icon><div id="element-name">${
+      config.name
+    }</div></div>
+    ${config.options.length > 0 ? this.downcast(config) : ''}`;
   }
 
   renderEdit(config) {
@@ -64,32 +89,56 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
     <tangy-form id="tangy-checkboxes">
       <tangy-form-item id="tangy-checkboxes">
         <template type="tangy-form-item">
-          <tangy-input name="name" label="Variable name" value="${config.name}" required></tangy-input>
-          <tangy-input name="label" label="Label" value="${config.label}"></tangy-input>
-          <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf}"></tangy-input>
-          <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-          <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-          <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
+          <tangy-input name="name" label="Variable name" value="${
+            config.name
+          }" required></tangy-input>
+          <tangy-input name="label" label="Label" value="${
+            config.label
+          }"></tangy-input>
+          <tangy-input name="tangy_if" label="Show if" value="${
+            config.tangyIf
+          }"></tangy-input>
+          <tangy-checkbox name="required" ${
+            config.required ? 'value="on"' : ''
+          }>Required</tangy-checkbox>
+          <tangy-checkbox name="disabled" ${
+            config.disabled ? 'value="on"' : ''
+          }>Disabled</tangy-checkbox>
+          <tangy-checkbox name="hidden" ${
+            config.hidden ? 'value="on"' : ''
+          }>Hidden</tangy-checkbox>
           <tangy-list name="options">
             <template type="tangy-list/new-item">
               <tangy-input name="value" label="Value" type="text"></tangy-input>
               <tangy-input name="label" label="Label" type="text"></tangy-input>
             </template>
-            ${config.options.length > 0 ? `
+            ${
+              config.options.length > 0
+                ? `
             <template type="tangy-list/initial-items">
-              ${config.options.map(option => `
+              ${config.options
+                .map(
+                  option => `
                 <tangy-list-item>
-                  <tangy-input name="value" label="Value" type="text" value="${option.value}"></tangy-input>
-                  <tangy-input name="label" label="Label" type="text" value="${option.label}"></tangy-input>
+                  <tangy-input name="value" label="Value" type="text" value="${
+                    option.value
+                  }"></tangy-input>
+                  <tangy-input name="label" label="Label" type="text" value="${
+                    option.label
+                  }"></tangy-input>
                 </tangy-list-item>  
-              `).join('')}
+              `
+                )
+                .join('')}
             </template>
-            ` : ''}
+            `
+                : ''
+            }
           </tangy-list>
         </template>
       </tangy-form-item>
     </tangy-form>
-    `
+    `;
   }
 
   editResponse(config) {
@@ -99,7 +148,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
       },
       items: [
         {
-          id: "tangy-checkboxes",
+          id: 'tangy-checkboxes',
           inputs: [
             {
               name: 'name',
@@ -112,7 +161,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
           ]
         }
       ]
-    }
+    };
   }
 
   onSubmit(config, formEl) {
@@ -123,13 +172,18 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
       required: formEl.values.required === 'on' ? true : false,
       hidden: formEl.values.hidden === 'on' ? true : false,
       disabled: formEl.values.disabled === 'on' ? true : false,
-      options: formEl.values.options.map(item => item.reduce((acc, input) => {
-        return {...acc, [input.name]: input.value}
-      }, {}))
-    }
+      options: formEl.values.options.map(item =>
+        item.reduce((acc, input) => {
+          return { ...acc, [input.name]: input.value };
+        }, {})
+      )
+    };
   }
-
 }
 
 window.customElements.define('tangy-checkboxes-widget', TangyCheckboxesWidget);
-window.tangyFormEditorWidgets.define('tangy-checkboxes-widget', 'tangy-checkboxes', TangyCheckboxesWidget);
+window.tangyFormEditorWidgets.define(
+  'tangy-checkboxes-widget',
+  'tangy-checkboxes',
+  TangyCheckboxesWidget
+);

--- a/widget/tangy-date-widget.js
+++ b/widget/tangy-date-widget.js
@@ -1,12 +1,11 @@
-import '@polymer/paper-card/paper-card.js'
-import '@polymer/paper-button/paper-button.js'
-import 'tangy-form/input/tangy-select.js'
-import { TangyBaseWidget } from '../tangy-base-widget.js'
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
+import 'tangy-form/input/tangy-select.js';
+import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyDateWidget extends TangyBaseWidget {
-
   get claimElement() {
-    return 'tangy-input[type=date]'
+    return 'tangy-input[type=date]';
   }
 
   get defaultConfig() {
@@ -18,16 +17,20 @@ class TangyDateWidget extends TangyBaseWidget {
       disabled: false,
       hidden: false,
       tangyIf: ''
-    }
+    };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyDate.props thus won't get picked up by TangyDate.getProps().
-    return {...config, ...element.getProps(), ...{
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if')
-        : ''
-    }}
+    return {
+      ...config,
+      ...element.getProps(),
+      ...{
+        tangyIf: element.hasAttribute('tangy-if')
+          ? element.getAttribute('tangy-if')
+          : ''
+      }
+    };
   }
 
   downcast(config) {
@@ -36,48 +39,104 @@ class TangyDateWidget extends TangyBaseWidget {
         name="${config.name}"
         label="${config.label}"
         type="date"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf}"`}
+        ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
       ></tangy-input>
-    `
+    `;
   }
-  
+  renderPrint(config) {
+    return `
+      
+      <table>
+        <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
+        <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+        <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+        <tr><td><strong>Type:</strong></td><td>${config.type}</td></tr>
+        <tr><td><strong>Error Message:</strong></td><td>${
+          config.errorMessage
+        }</td></tr>
+        <tr><td><strong>Allowed Pattern:</strong></td><td>${
+          config.allowedPattern
+        }</td></tr>
+        <tr><td><strong>Min:</strong></td><td>${config.min}</td></tr>
+        <tr><td><strong> Max:</strong></td><td>${config.max}</td></tr>
+        <tr><td><strong>Private:</strong></td><td>${config.private}</td></tr>
+        <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+        <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+        <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+      </table>
+      <hr/>
+    `;
+  }
   renderInfo(config) {
-    return `<div class="element-header"><mwc-icon>date_range</mwc-icon><div id="element-name">${config.name}</div></div>
-    ${this.downcast(config)}`
-
+    return `<div class="element-header"><mwc-icon>date_range</mwc-icon><div id="element-name">${
+      config.name
+    }</div></div>
+    ${this.downcast(config)}`;
   }
 
   renderEdit(config) {
     return `<h2>Add a Date Input</h2>
     <tangy-form id="tangy-date-widget">
       <tangy-form-item>
-        <tangy-input name="name" label="Variable name" value="${config.name}" required></tangy-input>
-        <tangy-input name="label" label="Label" value="${config.label}"></tangy-input>
-        <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf}"></tangy-input>
-        <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
+        <tangy-input name="name" label="Variable name" value="${
+          config.name
+        }" required></tangy-input>
+        <tangy-input name="label" label="Label" value="${
+          config.label
+        }"></tangy-input>
+        <tangy-input name="tangy_if" label="Show if" value="${
+          config.tangyIf
+        }"></tangy-input>
+        <tangy-checkbox name="required" ${
+          config.required ? 'value="on"' : ''
+        }>Required</tangy-checkbox>
+        <tangy-checkbox name="disabled" ${
+          config.disabled ? 'value="on"' : ''
+        }>Disabled</tangy-checkbox>
+        <tangy-checkbox name="hidden" ${
+          config.hidden ? 'value="on"' : ''
+        }>Hidden</tangy-checkbox>
       </tangy-form-item>
     </tangy-form>
-    `
+    `;
   }
 
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name').value,
-      label: formEl.response.items[0].inputs.find(input => input.name === 'label').value,
-      required: formEl.response.items[0].inputs.find(input => input.name === 'required').value === 'on' ? true : false,
-      hidden: formEl.response.items[0].inputs.find(input => input.name === 'hidden').value === 'on' ? true : false,
-      disabled: formEl.response.items[0].inputs.find(input => input.name === 'disabled').value === 'on' ? true : false,
-      tangyIf: formEl.response.items[0].inputs.find(input => input.name === 'tangy_if').value
-    }
+      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
+        .value,
+      label: formEl.response.items[0].inputs.find(
+        input => input.name === 'label'
+      ).value,
+      required:
+        formEl.response.items[0].inputs.find(input => input.name === 'required')
+          .value === 'on'
+          ? true
+          : false,
+      hidden:
+        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
+          .value === 'on'
+          ? true
+          : false,
+      disabled:
+        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
+          .value === 'on'
+          ? true
+          : false,
+      tangyIf: formEl.response.items[0].inputs.find(
+        input => input.name === 'tangy_if'
+      ).value
+    };
   }
-
 }
 
 window.customElements.define('tangy-date-widget', TangyDateWidget);
-window.tangyFormEditorWidgets.define('tangy-date-widget', 'tangy-input[type=date]', TangyDateWidget);
+window.tangyFormEditorWidgets.define(
+  'tangy-date-widget',
+  'tangy-input[type=date]',
+  TangyDateWidget
+);

--- a/widget/tangy-eftouch-widget.js
+++ b/widget/tangy-eftouch-widget.js
@@ -1,15 +1,14 @@
-import '@polymer/paper-card/paper-card.js'
-import '@polymer/paper-button/paper-button.js'
-import 'tangy-form/tangy-form.js'
-import 'tangy-form/input/tangy-eftouch.js'
-import 'tangy-form/input/tangy-input.js'
-import './tangy-eftouch-widget-layout.js'
-import { TangyBaseWidget } from '../tangy-base-widget.js'
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
+import 'tangy-form/tangy-form.js';
+import 'tangy-form/input/tangy-eftouch.js';
+import 'tangy-form/input/tangy-input.js';
+import './tangy-eftouch-widget-layout.js';
+import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyEftouchWidget extends TangyBaseWidget {
-
   get claimElement() {
-    return 'tangy-eftouch'
+    return 'tangy-eftouch';
   }
 
   get defaultConfig() {
@@ -27,16 +26,16 @@ class TangyEftouchWidget extends TangyBaseWidget {
       autoProgress: false,
       required: false,
       disabled: false,
-      hidden: false,
-    }
+      hidden: false
+    };
   }
 
   upcast(config, element) {
     return {
-      ...config, 
+      ...config,
       ...element.getProps(),
       optionsMarkup: element.innerHTML
-    }
+    };
   }
 
   downcast(config) {
@@ -58,12 +57,14 @@ class TangyEftouchWidget extends TangyBaseWidget {
       >
         ${config.optionsMarkup}
       </tangy-eftouch>
-    `
+    `;
   }
-  
+
   renderInfo(config) {
-    return `<div class="element-header"><div><mwc-icon>question_answer</mwc-icon></div><div id="element-name">${config.name}</div></div>
-    ${this.downcast(config)}`
+    return `<div class="element-header"><div><mwc-icon>question_answer</mwc-icon></div><div id="element-name">${
+      config.name
+    }</div></div>
+    ${this.downcast(config)}`;
   }
 
   renderEdit(config) {
@@ -71,28 +72,91 @@ class TangyEftouchWidget extends TangyBaseWidget {
     <tangy-form id="tangy-eftouch">
       <tangy-form-item id="tangy-eftouch">
         <template type="tangy-form-item">
-          <tangy-input name="name" label="Variable name" value="${config.name}" required></tangy-input>
-          <tangy-input name="label" label="Label" value="${config.label}"></tangy-input>
-          <tangy-input name="input-sound" label="Input sound" value="${config.inputSound}"></tangy-input>
-          <tangy-input name="transition-sound" label="Transition sound" value="${config.transitionSound}"></tangy-input>
-          <tangy-input name="transition-delay" label="Transition delay" value="${config.transitionDelay}" type="number"></tangy-input>
-          <tangy-input name="transition-message" label="Transition message" value="${config.transitionMessage}"></tangy-input>
-          <tangy-input name="warning-time" label="Warning time" value="${config.warningTime}"></tangy-input>
-          <tangy-input name="warning-message" label="Warning message" value="${config.warningMessage}"></tangy-input>
-          <tangy-input name="time-limit" label="Time limit" value="${config.timeLimit}"></tangy-input>
-          <tangy-checkbox name="auto-progress" ${config.autoProgress ? 'value="on"' : ''}>auto-progress</tangy-checkbox>
-          <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-          <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-          <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
+          <tangy-input name="name" label="Variable name" value="${
+            config.name
+          }" required></tangy-input>
+          <tangy-input name="label" label="Label" value="${
+            config.label
+          }"></tangy-input>
+          <tangy-input name="input-sound" label="Input sound" value="${
+            config.inputSound
+          }"></tangy-input>
+          <tangy-input name="transition-sound" label="Transition sound" value="${
+            config.transitionSound
+          }"></tangy-input>
+          <tangy-input name="transition-delay" label="Transition delay" value="${
+            config.transitionDelay
+          }" type="number"></tangy-input>
+          <tangy-input name="transition-message" label="Transition message" value="${
+            config.transitionMessage
+          }"></tangy-input>
+          <tangy-input name="warning-time" label="Warning time" value="${
+            config.warningTime
+          }"></tangy-input>
+          <tangy-input name="warning-message" label="Warning message" value="${
+            config.warningMessage
+          }"></tangy-input>
+          <tangy-input name="time-limit" label="Time limit" value="${
+            config.timeLimit
+          }"></tangy-input>
+          <tangy-checkbox name="auto-progress" ${
+            config.autoProgress ? 'value="on"' : ''
+          }>auto-progress</tangy-checkbox>
+          <tangy-checkbox name="required" ${
+            config.required ? 'value="on"' : ''
+          }>Required</tangy-checkbox>
+          <tangy-checkbox name="disabled" ${
+            config.disabled ? 'value="on"' : ''
+          }>Disabled</tangy-checkbox>
+          <tangy-checkbox name="hidden" ${
+            config.hidden ? 'value="on"' : ''
+          }>Hidden</tangy-checkbox>
           <tangy-eftouch-widget-layout name="options-markup">
             ${config.optionsMarkup}
           </tangy-eftouch-widget-layout>
         </template>
       </tangy-form-item>
     </tangy-form>
-    `
+    `;
   }
 
+  renderPrint(config) {
+    return `
+   
+    <table>
+    <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+    <tr><td><strong>Variable Label:</strong></td><td>${config.label}</td></tr>
+    <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+    <tr><td><strong>Input Sound:</strong></td><td>${config.inputSound}</td></tr>
+    <tr><td><strong>Transition Sound:</strong></td><td>${
+      config.transitionSound
+    }</td></tr>
+      <tr><td><strong>Transition Delay:</strong></td><td>${
+        config.transitionDelay
+      }</td></tr>
+      <tr><td><strong>Transition Message:</strong></td><td>${
+        config.transitionMessage
+      }</td></tr>
+      <tr><td><strong>Warning Time:</strong></td><td>${
+        config.warningTime
+      }</td></tr>
+      <tr><td><strong>Warning Message:</strong></td><td>${
+        config.warningMessage
+      }</td></tr>
+      <tr><td><strong>Time Limit:</strong></td><td>${config.timeLimit}</td></tr>
+      <tr><td><strong>Auto Progress:</strong></td><td>${
+        config.autoProgress
+      }</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+      <tr><td><strong>Options Markup:</strong></td><td><ul>${
+        config.optionsMarkup
+      }</ul></td></tr>
+    </table>
+    <hr/>
+    `;
+  }
   onSubmit(config, formEl) {
     return {
       ...config,
@@ -110,10 +174,13 @@ class TangyEftouchWidget extends TangyBaseWidget {
       hidden: formEl.values.hidden === 'on' ? true : false,
       disabled: formEl.values.disabled === 'on' ? true : false,
       optionsMarkup: formEl.values['options-markup']
-    }
+    };
   }
-
 }
 
 window.customElements.define('tangy-eftouch-widget', TangyEftouchWidget);
-window.tangyFormEditorWidgets.define('tangy-eftouch-widget', 'tangy-eftouch', TangyEftouchWidget);
+window.tangyFormEditorWidgets.define(
+  'tangy-eftouch-widget',
+  'tangy-eftouch',
+  TangyEftouchWidget
+);

--- a/widget/tangy-email-widget.js
+++ b/widget/tangy-email-widget.js
@@ -1,12 +1,11 @@
-import '@polymer/paper-card/paper-card.js'
-import '@polymer/paper-button/paper-button.js'
-import 'tangy-form/input/tangy-select.js'
-import { TangyBaseWidget } from '../tangy-base-widget.js'
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
+import 'tangy-form/input/tangy-select.js';
+import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyEmailWidget extends TangyBaseWidget {
-
   get claimElement() {
-    return 'tangy-input[type=email]'
+    return 'tangy-input[type=email]';
   }
 
   get defaultConfig() {
@@ -18,16 +17,20 @@ class TangyEmailWidget extends TangyBaseWidget {
       disabled: false,
       hidden: false,
       tangyIf: ''
-    }
+    };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyEmail.props thus won't get picked up by TangyEmail.getProps().
-    return {...config, ...element.getProps(), ...{
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if')
-        : ''
-    }}
+    return {
+      ...config,
+      ...element.getProps(),
+      ...{
+        tangyIf: element.hasAttribute('tangy-if')
+          ? element.getAttribute('tangy-if')
+          : ''
+      }
+    };
   }
 
   downcast(config) {
@@ -36,47 +39,102 @@ class TangyEmailWidget extends TangyBaseWidget {
         name="${config.name}"
         label="${config.label}"
         type="email"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf}"`}
+        ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
       ></tangy-input>
-    `
+    `;
   }
-  
+  renderPrint(config) {
+    return `
+   
+    <table>
+      <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
+      <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Type:</strong></td><td>${config.type}</td></tr>
+      <tr><td><strong>Error Message:</strong></td><td>${
+        config.errorMessage
+      }</td></tr>
+      <tr><td><strong>Allowed Pattern:</strong></td><td>${
+        config.allowedPattern
+      }</td></tr>
+      <tr><td><strong>Private:</strong></td><td>${config.private}</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+    </table>
+    <hr/>
+    `;
+  }
   renderInfo(config) {
-    return `<div class="element-header"><mwc-icon>emailr</mwc-icon><div id="element-name">${config.name}</div></div>
-    ${this.downcast(config)}`
+    return `<div class="element-header"><mwc-icon>emailr</mwc-icon><div id="element-name">${
+      config.name
+    }</div></div>
+    ${this.downcast(config)}`;
   }
 
   renderEdit(config) {
     return `<h2>Add Email Input</h2>
     <tangy-form id="tangy-email-widget">
       <tangy-form-item>
-        <tangy-input name="name" label="Variable name" value="${config.name}" required></tangy-input>
-        <tangy-input name="label" label="Label" value="${config.label}"></tangy-input>
-        <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf}"></tangy-input>
-        <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
+        <tangy-input name="name" label="Variable name" value="${
+          config.name
+        }" required></tangy-input>
+        <tangy-input name="label" label="Label" value="${
+          config.label
+        }"></tangy-input>
+        <tangy-input name="tangy_if" label="Show if" value="${
+          config.tangyIf
+        }"></tangy-input>
+        <tangy-checkbox name="required" ${
+          config.required ? 'value="on"' : ''
+        }>Required</tangy-checkbox>
+        <tangy-checkbox name="disabled" ${
+          config.disabled ? 'value="on"' : ''
+        }>Disabled</tangy-checkbox>
+        <tangy-checkbox name="hidden" ${
+          config.hidden ? 'value="on"' : ''
+        }>Hidden</tangy-checkbox>
       </tangy-form-item>
     </tangy-form>
-    `
+    `;
   }
 
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name').value,
-      label: formEl.response.items[0].inputs.find(input => input.name === 'label').value,
-      required: formEl.response.items[0].inputs.find(input => input.name === 'required').value === 'on' ? true : false,
-      hidden: formEl.response.items[0].inputs.find(input => input.name === 'hidden').value === 'on' ? true : false,
-      disabled: formEl.response.items[0].inputs.find(input => input.name === 'disabled').value === 'on' ? true : false,
-      tangyIf: formEl.response.items[0].inputs.find(input => input.name === 'tangy_if').value
-    }
+      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
+        .value,
+      label: formEl.response.items[0].inputs.find(
+        input => input.name === 'label'
+      ).value,
+      required:
+        formEl.response.items[0].inputs.find(input => input.name === 'required')
+          .value === 'on'
+          ? true
+          : false,
+      hidden:
+        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
+          .value === 'on'
+          ? true
+          : false,
+      disabled:
+        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
+          .value === 'on'
+          ? true
+          : false,
+      tangyIf: formEl.response.items[0].inputs.find(
+        input => input.name === 'tangy_if'
+      ).value
+    };
   }
-
 }
 
 window.customElements.define('tangy-email-widget', TangyEmailWidget);
-window.tangyFormEditorWidgets.define('tangy-email-widget', 'tangy-input[type=email]', TangyEmailWidget);
+window.tangyFormEditorWidgets.define(
+  'tangy-email-widget',
+  'tangy-input[type=email]',
+  TangyEmailWidget
+);

--- a/widget/tangy-gps-widget.js
+++ b/widget/tangy-gps-widget.js
@@ -1,12 +1,11 @@
-import '@polymer/paper-card/paper-card.js'
-import '@polymer/paper-button/paper-button.js'
-import 'tangy-form/input/tangy-select.js'
-import { TangyBaseWidget } from '../tangy-base-widget.js'
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
+import 'tangy-form/input/tangy-select.js';
+import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyGpsWidget extends TangyBaseWidget {
-
   get claimElement() {
-    return 'tangy-gps'
+    return 'tangy-gps';
   }
 
   get defaultConfig() {
@@ -16,61 +15,128 @@ class TangyGpsWidget extends TangyBaseWidget {
       disabled: false,
       hidden: false,
       tangyIf: ''
-    }
+    };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyGPS.props thus won't get picked up by TangyGPS.getProps().
-    return {...config, ...element.getProps(), ...{
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if')
-        : ''
-    }}
+    return {
+      ...config,
+      ...element.getProps(),
+      ...{
+        tangyIf: element.hasAttribute('tangy-if')
+          ? element.getAttribute('tangy-if')
+          : ''
+      }
+    };
   }
 
   downcast(config) {
     return `
       <tangy-gps 
         name="${config.name}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf}"`}
+        ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
       ></tangy-gps>
-    `
+    `;
   }
-  
+  renderPrint(config) {
+    return `
+   
+    <table>
+      <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Hide Accuracy Distance:</strong></td><td>${
+        config.hideAccuracyDistance
+      }</td></tr>
+      <tr><td><strong>Hide Accuracy Level:</strong></td><td>${
+        config.hideAccuracyLevel
+      }</td></tr>
+      <tr><td><strong>Hide Coordinates:</strong></td><td>${
+        config.hideCoordinates
+      }</td></tr>
+      <tr><td><strong>Reference Latitude:</strong></td><td>${
+        config.referenceLatitude
+      }</td></tr>
+      <tr><td><strong>Reference Longitude:</strong></td><td>${
+        config.referenceLongitude
+      }</td></tr>
+      <tr><td><strong>In Geofence:</strong></td><td>${
+        config.inGeofence
+      }</td></tr>
+      <tr><td><strong>Valid Max Delta:</strong></td><td>${
+        config.validMaxDelta
+      }</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+    </table>
+    <hr/>
+    `;
+  }
   renderInfo(config) {
-    return `<div class="element-header"><div><mwc-icon>add_location</mwc-icon></div><div id="element-name">${config.name}</div></div>
-    ${this.downcast(config)}`
+    return `<div class="element-header"><div><mwc-icon>add_location</mwc-icon></div><div id="element-name">${
+      config.name
+    }</div></div>
+    ${this.downcast(config)}`;
   }
 
   renderEdit(config) {
     return `<h2>Add GPS Element</h2>
     <tangy-form id="tangy-gps">
       <tangy-form-item>
-        <tangy-input name="name" label="Variable name" value="${config.name}" required></tangy-input>
-        <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf}"></tangy-input>
-        <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
+        <tangy-input name="name" label="Variable name" value="${
+          config.name
+        }" required></tangy-input>
+        <tangy-input name="tangy_if" label="Show if" value="${
+          config.tangyIf
+        }"></tangy-input>
+        <tangy-checkbox name="required" ${
+          config.required ? 'value="on"' : ''
+        }>Required</tangy-checkbox>
+        <tangy-checkbox name="disabled" ${
+          config.disabled ? 'value="on"' : ''
+        }>Disabled</tangy-checkbox>
+        <tangy-checkbox name="hidden" ${
+          config.hidden ? 'value="on"' : ''
+        }>Hidden</tangy-checkbox>
       </tangy-form-item>
     </tangy-form>
-    `
+    `;
   }
 
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name').value,
-      required: formEl.response.items[0].inputs.find(input => input.name === 'required').value === 'on' ? true : false,
-      hidden: formEl.response.items[0].inputs.find(input => input.name === 'hidden').value === 'on' ? true : false,
-      disabled: formEl.response.items[0].inputs.find(input => input.name === 'disabled').value === 'on' ? true : false,
-      tangyIf: formEl.response.items[0].inputs.find(input => input.name === 'tangy_if').value
-    }
+      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
+        .value,
+      required:
+        formEl.response.items[0].inputs.find(input => input.name === 'required')
+          .value === 'on'
+          ? true
+          : false,
+      hidden:
+        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
+          .value === 'on'
+          ? true
+          : false,
+      disabled:
+        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
+          .value === 'on'
+          ? true
+          : false,
+      tangyIf: formEl.response.items[0].inputs.find(
+        input => input.name === 'tangy_if'
+      ).value
+    };
   }
-
 }
 
 window.customElements.define('tangy-gps-widget', TangyGpsWidget);
-window.tangyFormEditorWidgets.define('tangy-gps-widget', 'tangy-gps', TangyGpsWidget);
+window.tangyFormEditorWidgets.define(
+  'tangy-gps-widget',
+  'tangy-gps',
+  TangyGpsWidget
+);

--- a/widget/tangy-location-widget.js
+++ b/widget/tangy-location-widget.js
@@ -1,13 +1,12 @@
-import '@polymer/paper-card/paper-card.js'
-import '@polymer/paper-button/paper-button.js'
-import 'tangy-form/input/tangy-location.js'
-import 'tangy-form/input/tangy-checkbox.js'
-import { TangyBaseWidget } from '../tangy-base-widget.js'
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
+import 'tangy-form/input/tangy-location.js';
+import 'tangy-form/input/tangy-checkbox.js';
+import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyLocationWidget extends TangyBaseWidget {
-
   get claimElement() {
-    return 'tangy-location'
+    return 'tangy-location';
   }
 
   get defaultConfig() {
@@ -21,24 +20,28 @@ class TangyLocationWidget extends TangyBaseWidget {
       metaDataTemplate: '',
       filterByGlobal: false,
       showLevels: ''
-    }
+    };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyLocation.props thus won't get picked up by TangyLocation.getProps().
-    return {...config, ...element.getProps(), ...{
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if')
-        : '',
-      metaDataTemplate: element.innerHTML
-    }}
+    return {
+      ...config,
+      ...element.getProps(),
+      ...{
+        tangyIf: element.hasAttribute('tangy-if')
+          ? element.getAttribute('tangy-if')
+          : '',
+        metaDataTemplate: element.innerHTML
+      }
+    };
   }
 
   downcast(config) {
     return `
       <tangy-location 
         name="${config.name}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf}"`}
+        ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
@@ -48,48 +51,112 @@ class TangyLocationWidget extends TangyBaseWidget {
       >
         ${config.metaDataTemplate}
       </tangy-location>
-    `
+    `;
   }
-  
+  renderPrint(config) {
+    return `
+
+    <table>
+      <tr><td><strong>Location Levels:</strong></td><td>${
+        config.showLevels
+      }</td></tr>
+      <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+    </table>
+    <hr/>
+    `;
+  }
   renderInfo(config) {
-    return `<div class="element-header"><div><mwc-icon>location_city</mwc-icon></div><div id="element-name">${config.name}</div></div>
-    ${this.downcast(config)}`
+    return `<div class="element-header"><div><mwc-icon>location_city</mwc-icon></div><div id="element-name">${
+      config.name
+    }</div></div>
+    ${this.downcast(config)}`;
   }
 
   renderEdit(config) {
     return `<h2>Add Location Element</h2>
     <tangy-form id="tangy-location">
       <tangy-form-item>
-        <tangy-input name="name" label="Variable name" value="${config.name}" required></tangy-input>
-        <tangy-checkbox name="filterByGlobal" ${config.filterByGlobal ? 'value="on"' : ''}>Filter by locations in the user profile?</tangy-checkbox>
-        <tangy-input name="showLevels" label="Show levels (ex. county,subcounty)" value="${config.showLevels}"></tangy-input>
-        <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf}"></tangy-input>
-        <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
-        <tangy-checkbox name="show-meta-data" ${config.showMetaData ? 'value="on"' : ''}>show meta-data</tangy-checkbox>
-        <tangy-input name="meta-data-template" label="Meta-data template" value="${config.metaDataTemplate}"></tangy-input>
+        <tangy-input name="name" label="Variable name" value="${
+          config.name
+        }" required></tangy-input>
+        <tangy-checkbox name="filterByGlobal" ${
+          config.filterByGlobal ? 'value="on"' : ''
+        }>Filter by locations in the user profile?</tangy-checkbox>
+        <tangy-input name="showLevels" label="Show levels (ex. county,subcounty)" value="${
+          config.showLevels
+        }"></tangy-input>
+        <tangy-input name="tangy_if" label="Show if" value="${
+          config.tangyIf
+        }"></tangy-input>
+        <tangy-checkbox name="required" ${
+          config.required ? 'value="on"' : ''
+        }>Required</tangy-checkbox>
+        <tangy-checkbox name="disabled" ${
+          config.disabled ? 'value="on"' : ''
+        }>Disabled</tangy-checkbox>
+        <tangy-checkbox name="hidden" ${
+          config.hidden ? 'value="on"' : ''
+        }>Hidden</tangy-checkbox>
+        <tangy-checkbox name="show-meta-data" ${
+          config.showMetaData ? 'value="on"' : ''
+        }>show meta-data</tangy-checkbox>
+        <tangy-input name="meta-data-template" label="Meta-data template" value="${
+          config.metaDataTemplate
+        }"></tangy-input>
       </tangy-form-item>
     </tangy-form>
-    `
+    `;
   }
 
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name').value,
-      required: formEl.response.items[0].inputs.find(input => input.name === 'required').value === 'on' ? true : false,
-      hidden: formEl.response.items[0].inputs.find(input => input.name === 'hidden').value === 'on' ? true : false,
-      disabled: formEl.response.items[0].inputs.find(input => input.name === 'disabled').value === 'on' ? true : false,
-      tangyIf: formEl.response.items[0].inputs.find(input => input.name === 'tangy_if').value,
-      filterByGlobal: formEl.response.items[0].inputs.find(input => input.name === 'filterByGlobal').value,
-      showLevels: formEl.response.items[0].inputs.find(input => input.name === 'showLevels').value,
-      showMetaData: formEl.response.items[0].inputs.find(input => input.name === 'show-meta-data').value === 'on' ? true : false,
-      metaDataTemplate: formEl.response.items[0].inputs.find(input => input.name === 'meta-data-template').value,
-    }
+      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
+        .value,
+      required:
+        formEl.response.items[0].inputs.find(input => input.name === 'required')
+          .value === 'on'
+          ? true
+          : false,
+      hidden:
+        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
+          .value === 'on'
+          ? true
+          : false,
+      disabled:
+        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
+          .value === 'on'
+          ? true
+          : false,
+      tangyIf: formEl.response.items[0].inputs.find(
+        input => input.name === 'tangy_if'
+      ).value,
+      filterByGlobal: formEl.response.items[0].inputs.find(
+        input => input.name === 'filterByGlobal'
+      ).value,
+      showLevels: formEl.response.items[0].inputs.find(
+        input => input.name === 'showLevels'
+      ).value,
+      showMetaData:
+        formEl.response.items[0].inputs.find(
+          input => input.name === 'show-meta-data'
+        ).value === 'on'
+          ? true
+          : false,
+      metaDataTemplate: formEl.response.items[0].inputs.find(
+        input => input.name === 'meta-data-template'
+      ).value
+    };
   }
-
 }
 
 window.customElements.define('tangy-location-widget', TangyLocationWidget);
-window.tangyFormEditorWidgets.define('tangy-location-widget', 'tangy-location', TangyLocationWidget);
+window.tangyFormEditorWidgets.define(
+  'tangy-location-widget',
+  'tangy-location',
+  TangyLocationWidget
+);

--- a/widget/tangy-number-widget.js
+++ b/widget/tangy-number-widget.js
@@ -1,12 +1,11 @@
-import '@polymer/paper-card/paper-card.js'
-import '@polymer/paper-button/paper-button.js'
-import 'tangy-form/input/tangy-select.js'
-import { TangyBaseWidget } from '../tangy-base-widget.js'
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
+import 'tangy-form/input/tangy-select.js';
+import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyNumberWidget extends TangyBaseWidget {
-
   get claimElement() {
-    return 'tangy-input[type=number]'
+    return 'tangy-input[type=number]';
   }
 
   get defaultConfig() {
@@ -21,16 +20,20 @@ class TangyNumberWidget extends TangyBaseWidget {
       min: undefined,
       max: undefined,
       tangyIf: ''
-    }
+    };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
-    return {...config, ...element.getProps(), ...{
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if')
-        : ''
-    }}
+    return {
+      ...config,
+      ...element.getProps(),
+      ...{
+        tangyIf: element.hasAttribute('tangy-if')
+          ? element.getAttribute('tangy-if')
+          : ''
+      }
+    };
   }
 
   downcast(config) {
@@ -39,54 +42,121 @@ class TangyNumberWidget extends TangyBaseWidget {
         name="${config.name}"
         label="${config.label}"
         type="number"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf}"`}
+        ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         allowed-pattern="${config.allowedPattern}"
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
       ></tangy-input>
-    `
-  }
-  
-  renderInfo(config) {
-    return `<div class="element-header"><div><mwc-icon>looks_one</mwc-icon></div><div id="element-name">${config.name}</div></div>
-    ${this.downcast(config)}`
+    `;
   }
 
+  renderInfo(config) {
+    return `<div class="element-header"><div><mwc-icon>looks_one</mwc-icon></div><div id="element-name">${
+      config.name
+    }</div></div>
+    ${this.downcast(config)}`;
+  }
+  renderPrint(config) {
+    return `
+      
+      <table>
+      <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
+      <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Type:</strong></td><td>${config.type}</td></tr>
+      <tr><td><strong>Error Message:</strong></td><td>${
+        config.errorMessage
+      }</td></tr>
+      <tr><td><strong>Allowed Pattern:</strong></td><td>${
+        config.allowedPattern
+      }</td></tr>
+      <tr><td><strong>Min:</strong></td><td>${config.min}</td></tr>
+      <tr><td><strong> Max:</strong></td><td>${config.max}</td></tr>
+      <tr><td><strong>Private:</strong></td><td>${config.private}</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+      </table>
+      <hr/>
+    `;
+  }
   renderEdit(config) {
     return `<h2>Add Number Input</h2>
     <tangy-form id="tangy-number-widget">
       <tangy-form-item>
-        <tangy-input name="name" label="Variable name" value="${config.name}" required></tangy-input>
-        <tangy-input name="label" label="Label" value="${config.label}"></tangy-input>
-        <tangy-input name="allowed_pattern" label="Allowed pattern" value="${config.allowedPattern}"></tangy-input>
-        <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf}"></tangy-input>
-        <tangy-input name="min" type="number" label="Minimum" value="${config.min}"></tangy-input>
-        <tangy-input name="max" type="number" label="Maximum" value="${config.max}"></tangy-input>
-        <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
+        <tangy-input name="name" label="Variable name" value="${
+          config.name
+        }" required></tangy-input>
+        <tangy-input name="label" label="Label" value="${
+          config.label
+        }"></tangy-input>
+        <tangy-input name="allowed_pattern" label="Allowed pattern" value="${
+          config.allowedPattern
+        }"></tangy-input>
+        <tangy-input name="tangy_if" label="Show if" value="${
+          config.tangyIf
+        }"></tangy-input>
+        <tangy-input name="min" type="number" label="Minimum" value="${
+          config.min
+        }"></tangy-input>
+        <tangy-input name="max" type="number" label="Maximum" value="${
+          config.max
+        }"></tangy-input>
+        <tangy-checkbox name="required" ${
+          config.required ? 'value="on"' : ''
+        }>Required</tangy-checkbox>
+        <tangy-checkbox name="disabled" ${
+          config.disabled ? 'value="on"' : ''
+        }>Disabled</tangy-checkbox>
+        <tangy-checkbox name="hidden" ${
+          config.hidden ? 'value="on"' : ''
+        }>Hidden</tangy-checkbox>
       </tangy-form-item>
     </tangy-form>
-    `
+    `;
   }
 
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name').value,
-      label: formEl.response.items[0].inputs.find(input => input.name === 'label').value,
-      min: formEl.response.items[0].inputs.find(input => input.name === 'min').value,
-      max: formEl.response.items[0].inputs.find(input => input.name === 'max').value,
-      required: formEl.response.items[0].inputs.find(input => input.name === 'required').value === 'on' ? true : false,
-      hidden: formEl.response.items[0].inputs.find(input => input.name === 'hidden').value === 'on' ? true : false,
-      disabled: formEl.response.items[0].inputs.find(input => input.name === 'disabled').value === 'on' ? true : false,
-      allowedPattern: formEl.response.items[0].inputs.find(input => input.name === 'allowed_pattern').value,
-      tangyIf: formEl.response.items[0].inputs.find(input => input.name === 'tangy_if').value
-    }
+      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
+        .value,
+      label: formEl.response.items[0].inputs.find(
+        input => input.name === 'label'
+      ).value,
+      min: formEl.response.items[0].inputs.find(input => input.name === 'min')
+        .value,
+      max: formEl.response.items[0].inputs.find(input => input.name === 'max')
+        .value,
+      required:
+        formEl.response.items[0].inputs.find(input => input.name === 'required')
+          .value === 'on'
+          ? true
+          : false,
+      hidden:
+        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
+          .value === 'on'
+          ? true
+          : false,
+      disabled:
+        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
+          .value === 'on'
+          ? true
+          : false,
+      allowedPattern: formEl.response.items[0].inputs.find(
+        input => input.name === 'allowed_pattern'
+      ).value,
+      tangyIf: formEl.response.items[0].inputs.find(
+        input => input.name === 'tangy_if'
+      ).value
+    };
   }
-
 }
 
 window.customElements.define('tangy-number-widget', TangyNumberWidget);
-window.tangyFormEditorWidgets.define('tangy-number-widget', 'tangy-input[type=number]', TangyNumberWidget);
+window.tangyFormEditorWidgets.define(
+  'tangy-number-widget',
+  'tangy-input[type=number]',
+  TangyNumberWidget
+);

--- a/widget/tangy-radio-buttons-widget.js
+++ b/widget/tangy-radio-buttons-widget.js
@@ -1,14 +1,13 @@
-import '@polymer/paper-card/paper-card.js'
-import '@polymer/paper-button/paper-button.js'
-import 'tangy-form/tangy-form.js'
-import 'tangy-form/input/tangy-radio-buttons.js'
-import 'tangy-form/input/tangy-input.js'
-import { TangyBaseWidget } from '../tangy-base-widget.js'
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
+import 'tangy-form/tangy-form.js';
+import 'tangy-form/input/tangy-radio-buttons.js';
+import 'tangy-form/input/tangy-input.js';
+import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyRadioButtonsWidget extends TangyBaseWidget {
-
   get claimElement() {
-    return 'tangy-radio-buttons'
+    return 'tangy-radio-buttons';
   }
 
   get defaultConfig() {
@@ -20,22 +19,24 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
       disabled: false,
       hidden: false,
       tangyIf: ''
-    }
+    };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
-    return {...config, ...element.getProps(),
+    return {
+      ...config,
+      ...element.getProps(),
       options: [...element.querySelectorAll('option')].map(option => {
         return {
           value: option.getAttribute('value'),
           label: option.innerHTML
-        }
+        };
       }),
       tangyIf: element.hasAttribute('tangy-if')
         ? element.getAttribute('tangy-if')
         : ''
-    }
+    };
   }
 
   downcast(config) {
@@ -47,16 +48,40 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
       >
-       ${config.options.map(option => `
+       ${config.options
+         .map(
+           option => `
        <option value="${option.value}">${option.label}</option>
-      `).join('')}
+      `
+         )
+         .join('')}
       </tangy-radio-buttons>
-    `
+    `;
   }
-
+  renderPrint(config) {
+    let keyValuePairs = '';
+    config.options.map(option => {
+      keyValuePairs += `<li>${option.value}: ${option.label}</li>`;
+    });
+    return `
+   
+    <table>
+      <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
+      <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+      <tr><td><strong>Options:</strong></td><td><ul>${keyValuePairs}</ul></td></tr>
+    </table>
+    <hr/>
+    `;
+  }
   renderInfo(config) {
-    return `<div class="element-header"><div><mwc-icon>radio_button_unchecked</mwc-icon></div><div id="element-name">${config.name}</div></div>
-    ${config.options.length > 0 ? this.downcast(config) : ''}`
+    return `<div class="element-header"><div><mwc-icon>radio_button_unchecked</mwc-icon></div><div id="element-name">${
+      config.name
+    }</div></div>
+    ${config.options.length > 0 ? this.downcast(config) : ''}`;
   }
 
   renderEdit(config) {
@@ -64,32 +89,56 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
     <tangy-form id="tangy-radio-buttons">
       <tangy-form-item id="tangy-radio-buttons">
         <template type="tangy-form-item">
-          <tangy-input name="name" label="Variable name" value="${config.name}" required></tangy-input>
-          <tangy-input name="label" label="Label" value="${config.label}"></tangy-input>
-          <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf}"></tangy-input>
-          <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-          <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-          <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
+          <tangy-input name="name" label="Variable name" value="${
+            config.name
+          }" required></tangy-input>
+          <tangy-input name="label" label="Label" value="${
+            config.label
+          }"></tangy-input>
+          <tangy-input name="tangy_if" label="Show if" value="${
+            config.tangyIf
+          }"></tangy-input>
+          <tangy-checkbox name="required" ${
+            config.required ? 'value="on"' : ''
+          }>Required</tangy-checkbox>
+          <tangy-checkbox name="disabled" ${
+            config.disabled ? 'value="on"' : ''
+          }>Disabled</tangy-checkbox>
+          <tangy-checkbox name="hidden" ${
+            config.hidden ? 'value="on"' : ''
+          }>Hidden</tangy-checkbox>
           <tangy-list name="options">
             <template type="tangy-list/new-item">
               <tangy-input name="value" label="Value" type="text"></tangy-input>
               <tangy-input name="label" label="Label" type="text"></tangy-input>
             </template>
-            ${config.options.length > 0 ? `
+            ${
+              config.options.length > 0
+                ? `
             <template type="tangy-list/initial-items">
-              ${config.options.map(option => `
+              ${config.options
+                .map(
+                  option => `
                 <tangy-list-item>
-                  <tangy-input name="value" label="Value" type="text" value="${option.value}"></tangy-input>
-                  <tangy-input name="label" label="Label" type="text" value="${option.label}"></tangy-input>
+                  <tangy-input name="value" label="Value" type="text" value="${
+                    option.value
+                  }"></tangy-input>
+                  <tangy-input name="label" label="Label" type="text" value="${
+                    option.label
+                  }"></tangy-input>
                 </tangy-list-item>
-              `).join('')}
+              `
+                )
+                .join('')}
             </template>
-            ` : ''}
+            `
+                : ''
+            }
           </tangy-list>
         </template>
       </tangy-form-item>
     </tangy-form>
-    `
+    `;
   }
 
   editResponse(config) {
@@ -99,7 +148,7 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
       },
       items: [
         {
-          id: "tangy-radio-buttons",
+          id: 'tangy-radio-buttons',
           inputs: [
             {
               name: 'name',
@@ -112,7 +161,7 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
           ]
         }
       ]
-    }
+    };
   }
 
   onSubmit(config, formEl) {
@@ -123,13 +172,21 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
       required: formEl.values.required === 'on' ? true : false,
       hidden: formEl.values.hidden === 'on' ? true : false,
       disabled: formEl.values.disabled === 'on' ? true : false,
-      options: formEl.values.options.map(item => item.reduce((acc, input) => {
-        return {...acc, [input.name]: input.value}
-      }, {}))
-    }
+      options: formEl.values.options.map(item =>
+        item.reduce((acc, input) => {
+          return { ...acc, [input.name]: input.value };
+        }, {})
+      )
+    };
   }
-
 }
 
-window.customElements.define('tangy-radio-buttons-widget', TangyRadioButtonsWidget);
-window.tangyFormEditorWidgets.define('tangy-radio-buttons-widget', 'tangy-radio-buttons', TangyRadioButtonsWidget);
+window.customElements.define(
+  'tangy-radio-buttons-widget',
+  TangyRadioButtonsWidget
+);
+window.tangyFormEditorWidgets.define(
+  'tangy-radio-buttons-widget',
+  'tangy-radio-buttons',
+  TangyRadioButtonsWidget
+);

--- a/widget/tangy-select-widget.js
+++ b/widget/tangy-select-widget.js
@@ -1,14 +1,13 @@
-import '@polymer/paper-card/paper-card.js'
-import '@polymer/paper-button/paper-button.js'
-import 'tangy-form/tangy-form.js'
-import 'tangy-form/input/tangy-select.js'
-import 'tangy-form/input/tangy-input.js'
-import { TangyBaseWidget } from '../tangy-base-widget.js'
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
+import 'tangy-form/tangy-form.js';
+import 'tangy-form/input/tangy-select.js';
+import 'tangy-form/input/tangy-input.js';
+import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangySelectWidget extends TangyBaseWidget {
-
   get claimElement() {
-    return 'tangy-select'
+    return 'tangy-select';
   }
 
   get defaultConfig() {
@@ -20,22 +19,24 @@ class TangySelectWidget extends TangyBaseWidget {
       disabled: false,
       hidden: false,
       tangyIf: ''
-    }
+    };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
-    return {...config, ...element.getProps(),
+    return {
+      ...config,
+      ...element.getProps(),
       options: [...element.querySelectorAll('option')].map(option => {
         return {
           value: option.getAttribute('value'),
           label: option.innerHTML
-        }
+        };
       }),
       tangyIf: element.hasAttribute('tangy-if')
         ? element.getAttribute('tangy-if')
         : ''
-    }
+    };
   }
 
   downcast(config) {
@@ -47,16 +48,43 @@ class TangySelectWidget extends TangyBaseWidget {
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
       >
-       ${config.options.map(option => `
+       ${config.options
+         .map(
+           option => `
          <option value="${option.value}">${option.label}</option>
-      `).join('')}
+      `
+         )
+         .join('')}
       </tangy-select>
-    `
+    `;
   }
-
+  renderPrint(config) {
+    let keyValuePairs = '';
+    config.options.map(option => {
+      keyValuePairs += `<li>${option.value}: ${option.label}</li>`;
+    });
+    return `
+   
+    <table>
+      <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
+      <tr><td><strong>Secondary Label:</strong></td><td>${
+        config.secondaryLabel
+      }</td></tr>
+      <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+      <tr><td><strong>Options:</strong></td><td><ul>${keyValuePairs}</ul></td></tr>
+    </table>
+    <hr/>
+    `;
+  }
   renderInfo(config) {
-    return `<div class="element-header"><div><mwc-icon>arrow_drop_down_circle</mwc-icon></div><div id="element-name">${config.name}</div></div>
-    ${config.options.length > 0 ? this.downcast(config) : ''}`
+    return `<div class="element-header"><div><mwc-icon>arrow_drop_down_circle</mwc-icon></div><div id="element-name">${
+      config.name
+    }</div></div>
+    ${config.options.length > 0 ? this.downcast(config) : ''}`;
   }
 
   renderEdit(config) {
@@ -64,32 +92,56 @@ class TangySelectWidget extends TangyBaseWidget {
     <tangy-form id="tangy-select">
       <tangy-form-item id="tangy-select">
         <template type="tangy-form-item">
-          <tangy-input name="name" label="Variable name" value="${config.name}" required></tangy-input>
-          <tangy-input name="label" label="Label" value="${config.label}"></tangy-input>
-          <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf}"></tangy-input>
-          <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-          <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-          <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
+          <tangy-input name="name" label="Variable name" value="${
+            config.name
+          }" required></tangy-input>
+          <tangy-input name="label" label="Label" value="${
+            config.label
+          }"></tangy-input>
+          <tangy-input name="tangy_if" label="Show if" value="${
+            config.tangyIf
+          }"></tangy-input>
+          <tangy-checkbox name="required" ${
+            config.required ? 'value="on"' : ''
+          }>Required</tangy-checkbox>
+          <tangy-checkbox name="disabled" ${
+            config.disabled ? 'value="on"' : ''
+          }>Disabled</tangy-checkbox>
+          <tangy-checkbox name="hidden" ${
+            config.hidden ? 'value="on"' : ''
+          }>Hidden</tangy-checkbox>
           <tangy-list name="options">
             <template type="tangy-list/new-item">
               <tangy-input name="value" label="Value" type="text"></tangy-input>
               <tangy-input name="label" label="Label" type="text"></tangy-input>
             </template>
-            ${config.options.length > 0 ? `
+            ${
+              config.options.length > 0
+                ? `
             <template type="tangy-list/initial-items">
-              ${config.options.map(option => `
+              ${config.options
+                .map(
+                  option => `
                 <tangy-list-item>
-                  <tangy-input name="value" label="Value" type="text" value="${option.value}"></tangy-input>
-                  <tangy-input name="label" label="Label" type="text" value="${option.label}"></tangy-input>
+                  <tangy-input name="value" label="Value" type="text" value="${
+                    option.value
+                  }"></tangy-input>
+                  <tangy-input name="label" label="Label" type="text" value="${
+                    option.label
+                  }"></tangy-input>
                 </tangy-list-item>
-              `).join('')}
+              `
+                )
+                .join('')}
             </template>
-            ` : ''}
+            `
+                : ''
+            }
           </tangy-list>
         </template>
       </tangy-form-item>
     </tangy-form>
-    `
+    `;
   }
 
   editResponse(config) {
@@ -99,7 +151,7 @@ class TangySelectWidget extends TangyBaseWidget {
       },
       items: [
         {
-          id: "tangy-select",
+          id: 'tangy-select',
           inputs: [
             {
               name: 'name',
@@ -112,7 +164,7 @@ class TangySelectWidget extends TangyBaseWidget {
           ]
         }
       ]
-    }
+    };
   }
 
   onSubmit(config, formEl) {
@@ -123,13 +175,18 @@ class TangySelectWidget extends TangyBaseWidget {
       required: formEl.values.required === 'on' ? true : false,
       hidden: formEl.values.hidden === 'on' ? true : false,
       disabled: formEl.values.disabled === 'on' ? true : false,
-      options: formEl.values.options.map(item => item.reduce((acc, input) => {
-        return {...acc, [input.name]: input.value}
-      }, {}))
-    }
+      options: formEl.values.options.map(item =>
+        item.reduce((acc, input) => {
+          return { ...acc, [input.name]: input.value };
+        }, {})
+      )
+    };
   }
-
 }
 
 window.customElements.define('tangy-select-widget', TangySelectWidget);
-window.tangyFormEditorWidgets.define('tangy-select-widget', 'tangy-select', TangySelectWidget);
+window.tangyFormEditorWidgets.define(
+  'tangy-select-widget',
+  'tangy-select',
+  TangySelectWidget
+);

--- a/widget/tangy-text-widget.js
+++ b/widget/tangy-text-widget.js
@@ -1,12 +1,11 @@
-import '@polymer/paper-card/paper-card.js'
-import '@polymer/paper-button/paper-button.js'
-import 'tangy-form/input/tangy-select.js'
-import { TangyBaseWidget } from '../tangy-base-widget.js'
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
+import 'tangy-form/input/tangy-select.js';
+import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyTextWidget extends TangyBaseWidget {
-
   get claimElement() {
-    return 'tangy-input[type=text], tangy-input:not([type])'
+    return 'tangy-input[type=text], tangy-input:not([type])';
   }
   get defaultConfig() {
     return {
@@ -18,16 +17,20 @@ class TangyTextWidget extends TangyBaseWidget {
       hidden: false,
       allowedPattern: '',
       tangyIf: ''
-    }
+    };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
-    return {...config, ...element.getProps(), ...{
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if')
-        : ''
-    }}
+    return {
+      ...config,
+      ...element.getProps(),
+      ...{
+        tangyIf: element.hasAttribute('tangy-if')
+          ? element.getAttribute('tangy-if')
+          : ''
+      }
+    };
   }
 
   downcast(config) {
@@ -36,59 +39,111 @@ class TangyTextWidget extends TangyBaseWidget {
         name="${config.name}"
         label="${config.label}"
         type="text"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf}"`}
+        ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         allowed-pattern="${config.allowedPattern}"
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
       ></tangy-input>
-    `
+    `;
   }
 
   renderPrint(config) {
     return `
-      <strong>Variable name:</strong> ${config.name},
-      <strong>Type:</strong> Text,
-      <strong>Prompt:</strong> ${config.label} <br>
-      ${this.downcast(config)}
-    `
+   
+    <table>
+      <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
+      <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Type:</strong></td><td>${config.type}</td></tr>
+      <tr><td><strong>Error Message:</strong></td><td>${
+        config.errorMessage
+      }</td></tr>
+      <tr><td><strong>Allowed Pattern:</strong></td><td>${
+        config.allowedPattern
+      }</td></tr>
+      <tr><td><strong>Private:</strong></td><td>${config.private}</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+    </table>
+    <hr/>
+    `;
   }
-  
+
   renderInfo(config) {
-    return `<div class="element-header"><div><mwc-icon>text_fields</mwc-icon></div><div id="element-name">${config.name}</div></div>
-    ${this.downcast(config)}`
+    return `<div class="element-header"><div><mwc-icon>text_fields</mwc-icon></div><div id="element-name">${
+      config.name
+    }</div></div>
+    ${this.downcast(config)}`;
   }
 
   renderEdit(config) {
     return `<h2>Add Text Input</h2>
     <tangy-form id="tangy-input">
       <tangy-form-item>
-        <tangy-input name="name" label="Variable name" value="${config.name}" required></tangy-input>
-        <tangy-input name="label" label="Label" value="${config.label}"></tangy-input>
-        <tangy-input name="allowed_pattern" label="Allowed pattern" value="${config.allowedPattern}"></tangy-input>
-        <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf}"></tangy-input>
-        <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
+        <tangy-input name="name" label="Variable name" value="${
+          config.name
+        }" required></tangy-input>
+        <tangy-input name="label" label="Label" value="${
+          config.label
+        }"></tangy-input>
+        <tangy-input name="allowed_pattern" label="Allowed pattern" value="${
+          config.allowedPattern
+        }"></tangy-input>
+        <tangy-input name="tangy_if" label="Show if" value="${
+          config.tangyIf
+        }"></tangy-input>
+        <tangy-checkbox name="required" ${
+          config.required ? 'value="on"' : ''
+        }>Required</tangy-checkbox>
+        <tangy-checkbox name="disabled" ${
+          config.disabled ? 'value="on"' : ''
+        }>Disabled</tangy-checkbox>
+        <tangy-checkbox name="hidden" ${
+          config.hidden ? 'value="on"' : ''
+        }>Hidden</tangy-checkbox>
       </tangy-form-item>
     </tangy-form>
-    `
+    `;
   }
 
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name').value,
-      label: formEl.response.items[0].inputs.find(input => input.name === 'label').value,
-      required: formEl.response.items[0].inputs.find(input => input.name === 'required').value === 'on' ? true : false,
-      hidden: formEl.response.items[0].inputs.find(input => input.name === 'hidden').value === 'on' ? true : false,
-      disabled: formEl.response.items[0].inputs.find(input => input.name === 'disabled').value === 'on' ? true : false,
-      allowedPattern: formEl.response.items[0].inputs.find(input => input.name === 'allowed_pattern').value,
-      tangyIf: formEl.response.items[0].inputs.find(input => input.name === 'tangy_if').value
-    }
+      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
+        .value,
+      label: formEl.response.items[0].inputs.find(
+        input => input.name === 'label'
+      ).value,
+      required:
+        formEl.response.items[0].inputs.find(input => input.name === 'required')
+          .value === 'on'
+          ? true
+          : false,
+      hidden:
+        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
+          .value === 'on'
+          ? true
+          : false,
+      disabled:
+        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
+          .value === 'on'
+          ? true
+          : false,
+      allowedPattern: formEl.response.items[0].inputs.find(
+        input => input.name === 'allowed_pattern'
+      ).value,
+      tangyIf: formEl.response.items[0].inputs.find(
+        input => input.name === 'tangy_if'
+      ).value
+    };
   }
-
 }
 
 window.customElements.define('tangy-text-widget', TangyTextWidget);
-window.tangyFormEditorWidgets.define('tangy-text-widget', 'tangy-input[type=text], tangy-input:not([type])', TangyTextWidget);
+window.tangyFormEditorWidgets.define(
+  'tangy-text-widget',
+  'tangy-input[type=text], tangy-input:not([type])',
+  TangyTextWidget
+);

--- a/widget/tangy-time-widget.js
+++ b/widget/tangy-time-widget.js
@@ -1,12 +1,11 @@
-import '@polymer/paper-card/paper-card.js'
-import '@polymer/paper-button/paper-button.js'
-import 'tangy-form/input/tangy-select.js'
-import { TangyBaseWidget } from '../tangy-base-widget.js'
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
+import 'tangy-form/input/tangy-select.js';
+import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyTimeWidget extends TangyBaseWidget {
-
   get claimElement() {
-    return 'tangy-input[type=time]'
+    return 'tangy-input[type=time]';
   }
 
   get defaultConfig() {
@@ -18,16 +17,20 @@ class TangyTimeWidget extends TangyBaseWidget {
       disabled: false,
       hidden: false,
       tangyIf: ''
-    }
+    };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyTime.props thus won't get picked up by TangyTime.getProps().
-    return {...config, ...element.getProps(), ...{
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if')
-        : ''
-    }}
+    return {
+      ...config,
+      ...element.getProps(),
+      ...{
+        tangyIf: element.hasAttribute('tangy-if')
+          ? element.getAttribute('tangy-if')
+          : ''
+      }
+    };
   }
 
   downcast(config) {
@@ -36,47 +39,99 @@ class TangyTimeWidget extends TangyBaseWidget {
         name="${config.name}"
         label="${config.label}"
         type="time"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf}"`}
+        ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
       ></tangy-input>
-    `
+    `;
   }
-  
+  renderPrint(config) {
+    return `
+   
+    <table>
+      <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
+      <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Type:</strong></td><td>${config.type}</td></tr>
+      <tr><td><strong>Error Message:</strong></td><td>${
+        config.errorMessage
+      }</td></tr>
+      <tr><td><strong>Private:</strong></td><td>${config.private}</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+    </table>
+    <hr/>
+    `;
+  }
   renderInfo(config) {
-    return `<div class="element-header"><mwc-icon>timer</mwc-icon><div id="element-name">${config.name}</div></div>
-    ${this.downcast(config)}`
+    return `<div class="element-header"><mwc-icon>timer</mwc-icon><div id="element-name">${
+      config.name
+    }</div></div>
+    ${this.downcast(config)}`;
   }
 
   renderEdit(config) {
     return `<h2>Add Time Input</h2>
     <tangy-form id="tangy-time-widget">
       <tangy-form-item>
-        <tangy-input name="name" label="Variable name" value="${config.name}" required></tangy-input>
-        <tangy-input name="label" label="Label" value="${config.label}"></tangy-input>
-        <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf}"></tangy-input>
-        <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
+        <tangy-input name="name" label="Variable name" value="${
+          config.name
+        }" required></tangy-input>
+        <tangy-input name="label" label="Label" value="${
+          config.label
+        }"></tangy-input>
+        <tangy-input name="tangy_if" label="Show if" value="${
+          config.tangyIf
+        }"></tangy-input>
+        <tangy-checkbox name="required" ${
+          config.required ? 'value="on"' : ''
+        }>Required</tangy-checkbox>
+        <tangy-checkbox name="disabled" ${
+          config.disabled ? 'value="on"' : ''
+        }>Disabled</tangy-checkbox>
+        <tangy-checkbox name="hidden" ${
+          config.hidden ? 'value="on"' : ''
+        }>Hidden</tangy-checkbox>
       </tangy-form-item>
     </tangy-form>
-    `
+    `;
   }
 
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name').value,
-      label: formEl.response.items[0].inputs.find(input => input.name === 'label').value,
-      required: formEl.response.items[0].inputs.find(input => input.name === 'required').value === 'on' ? true : false,
-      hidden: formEl.response.items[0].inputs.find(input => input.name === 'hidden').value === 'on' ? true : false,
-      disabled: formEl.response.items[0].inputs.find(input => input.name === 'disabled').value === 'on' ? true : false,
-      tangyIf: formEl.response.items[0].inputs.find(input => input.name === 'tangy_if').value
-    }
+      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
+        .value,
+      label: formEl.response.items[0].inputs.find(
+        input => input.name === 'label'
+      ).value,
+      required:
+        formEl.response.items[0].inputs.find(input => input.name === 'required')
+          .value === 'on'
+          ? true
+          : false,
+      hidden:
+        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
+          .value === 'on'
+          ? true
+          : false,
+      disabled:
+        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
+          .value === 'on'
+          ? true
+          : false,
+      tangyIf: formEl.response.items[0].inputs.find(
+        input => input.name === 'tangy_if'
+      ).value
+    };
   }
-
 }
 
 window.customElements.define('tangy-time-widget', TangyTimeWidget);
-window.tangyFormEditorWidgets.define('tangy-time-widget', 'tangy-input[type=time]', TangyTimeWidget);
+window.tangyFormEditorWidgets.define(
+  'tangy-time-widget',
+  'tangy-input[type=time]',
+  TangyTimeWidget
+);

--- a/widget/tangy-timed-widget.js
+++ b/widget/tangy-timed-widget.js
@@ -1,15 +1,14 @@
- import '@polymer/paper-card/paper-card.js'
-import '@polymer/paper-button/paper-button.js'
-import '@polymer/paper-input/paper-textarea.js'
-import 'tangy-form/tangy-form.js'
-import 'tangy-form/input/tangy-timed.js'
-import 'tangy-form/input/tangy-input.js'
-import { TangyBaseWidget } from '../tangy-base-widget.js'
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
+import '@polymer/paper-input/paper-textarea.js';
+import 'tangy-form/tangy-form.js';
+import 'tangy-form/input/tangy-timed.js';
+import 'tangy-form/input/tangy-input.js';
+import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyTimedWidget extends TangyBaseWidget {
-
   get claimElement() {
-    return 'tangy-timed'
+    return 'tangy-timed';
   }
 
   get defaultConfig() {
@@ -21,22 +20,24 @@ class TangyTimedWidget extends TangyBaseWidget {
       disabled: false,
       hidden: false,
       tangyIf: ''
-    }
+    };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyTimed.props thus won't get picked up by TangyTimed.getProps().
-    return {...config, ...element.getProps(),
+    return {
+      ...config,
+      ...element.getProps(),
       options: [...element.querySelectorAll('option')].map(option => {
         return {
           name: option.getAttribute('value'),
           label: option.innerHTML
-        }
+        };
       }),
       tangyIf: element.hasAttribute('tangy-if')
         ? element.getAttribute('tangy-if')
         : ''
-    }
+    };
   }
 
   downcast(config) {
@@ -48,16 +49,46 @@ class TangyTimedWidget extends TangyBaseWidget {
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
       >
-      ${config.options.map(option => `
+      ${config.options
+        .map(
+          option => `
         <option value="${option.value}">${option.label}</option>
-      `).join('')}
+      `
+        )
+        .join('')}
       </tangy-timed>
-    `
+    `;
   }
-
+  renderPrint(config) {
+    let str = '';
+    config.options.map(option => {
+      str += `${option.label}, `;
+    });
+    const gridValues = str.substring(0, str.length - 1);
+    return `
+   
+    <table>
+    <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+    <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+    <tr><td><strong>Duration:</strong></td><td>${config.duration}</td></tr>
+    <tr><td><strong>Mode:</strong></td><td>${config.mode}</td></tr>
+      <tr><td><strong>Columns:</strong></td><td>${config.columns}</td></tr>
+      <tr><td><strong>Show Labels:</strong></td><td>${
+        config.showLabels
+      }</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+      <tr><td><strong>Options:</strong></td><td><ul>${gridValues}</ul></td></tr>
+    </table>
+    <hr/>
+    `;
+  }
   renderInfo(config) {
-    return `<div class="element-header"><div><mwc-icon>av_timer</mwc-icon></div><div id="element-name">${config.name}</div></div>
-    ${this.downcast(config)}`
+    return `<div class="element-header"><div><mwc-icon>av_timer</mwc-icon></div><div id="element-name">${
+      config.name
+    }</div></div>
+    ${this.downcast(config)}`;
   }
 
   renderEdit(config) {
@@ -65,18 +96,34 @@ class TangyTimedWidget extends TangyBaseWidget {
     <tangy-form id="tangy-timed">
       <tangy-form-item id="tangy-timed">
         <template type="tangy-form-item">
-          <tangy-input name="name" label="Variable name" value="${config.name}" required></tangy-input>
-          <tangy-input name="label" label="Label" value="${config.label}"></tangy-input>
-          <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf}"></tangy-input>
-          <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-          <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-          <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
-          <tangy-input name="duration" label="Duration in seconds" value="${config.duration}"></tangy-input>
-          <tangy-input name="options"  label="Options (Each option separated by a space)" value="${config.options.map(option => `${option.label}`).join(' ')}"></tangy-input>
+          <tangy-input name="name" label="Variable name" value="${
+            config.name
+          }" required></tangy-input>
+          <tangy-input name="label" label="Label" value="${
+            config.label
+          }"></tangy-input>
+          <tangy-input name="tangy_if" label="Show if" value="${
+            config.tangyIf
+          }"></tangy-input>
+          <tangy-checkbox name="required" ${
+            config.required ? 'value="on"' : ''
+          }>Required</tangy-checkbox>
+          <tangy-checkbox name="disabled" ${
+            config.disabled ? 'value="on"' : ''
+          }>Disabled</tangy-checkbox>
+          <tangy-checkbox name="hidden" ${
+            config.hidden ? 'value="on"' : ''
+          }>Hidden</tangy-checkbox>
+          <tangy-input name="duration" label="Duration in seconds" value="${
+            config.duration
+          }"></tangy-input>
+          <tangy-input name="options"  label="Options (Each option separated by a space)" value="${config.options
+            .map(option => `${option.label}`)
+            .join(' ')}"></tangy-input>
         </template>
       </tangy-form-item>
     </tangy-form>
-    `
+    `;
   }
 
   editResponse(config) {
@@ -86,7 +133,7 @@ class TangyTimedWidget extends TangyBaseWidget {
       },
       items: [
         {
-          id: "tangy-timed",
+          id: 'tangy-timed',
           inputs: [
             {
               name: 'name',
@@ -99,7 +146,7 @@ class TangyTimedWidget extends TangyBaseWidget {
           ]
         }
       ]
-    }
+    };
   }
 
   onSubmit(config, formEl) {
@@ -111,12 +158,15 @@ class TangyTimedWidget extends TangyBaseWidget {
       hidden: formEl.values.hidden === 'on' ? true : false,
       disabled: formEl.values.disabled === 'on' ? true : false,
       options: formEl.values.options.split(' ').map((item, i) => {
-        return {value: i, label: item}
+        return { value: i, label: item };
       })
-    }
+    };
   }
-
 }
 
 window.customElements.define('tangy-timed-widget', TangyTimedWidget);
-window.tangyFormEditorWidgets.define('tangy-timed-widget', 'tangy-timed', TangyTimedWidget);
+window.tangyFormEditorWidgets.define(
+  'tangy-timed-widget',
+  'tangy-timed',
+  TangyTimedWidget
+);


### PR DESCRIPTION
## Problem/Feature
* Fixes Tangerine-Community/Tangerine#1287
* When printing a form, the print output should be formatted in a way that is easily readable.

## Approach/Solution

* Customize the `renderPrint` function of every widget to `return` the corresponding markup

## Limitations/Trade-offs
* When printing the `options` in the `tangy-timed-widget` the `options` are space delimited. This may lead to very long strings when there are several options