### PR TITLE
Added hint text attribute to editor widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "js-beautify": "^1.7.5",
     "juicy-ace-editor": "git://github.com/Juicy/juicy-ace-editor.git#ES6-modules",
     "redux": "^4.0.0",
-    "tangy-form": "^3.4.1"
+    "tangy-form": "^3.5.0"
   },
   "devDependencies": {
     "@polymer/iron-demo-helpers": "^3.0.0-pre.19",

--- a/widget/tangy-checkboxes-widget.js
+++ b/widget/tangy-checkboxes-widget.js
@@ -45,7 +45,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
       <tangy-checkboxes
         name="${config.name}"
         label="${config.label}"
-        hintText="${config.hintText}"
+        hint-text="${config.hintText}"
         ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
@@ -175,6 +175,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
       required: formEl.values.required === 'on' ? true : false,
       hidden: formEl.values.hidden === 'on' ? true : false,
       disabled: formEl.values.disabled === 'on' ? true : false,
+      hintText: formEl.values.hintText,
       options: formEl.values.options.map(item =>
         item.reduce((acc, input) => {
           return { ...acc, [input.name]: input.value };

--- a/widget/tangy-checkboxes-widget.js
+++ b/widget/tangy-checkboxes-widget.js
@@ -14,6 +14,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
     return {
       name: '',
       label: '',
+      hintText: '',
       options: [],
       required: false,
       disabled: false,
@@ -44,6 +45,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
       <tangy-checkboxes
         name="${config.name}"
         label="${config.label}"
+        hintText="${config.hintText}"
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
@@ -68,7 +70,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
     <table>
       <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
-      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hintText}</td></tr>
       <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
       <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
       <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
@@ -94,6 +96,9 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
           }" required></tangy-input>
           <tangy-input name="label" label="Label" value="${
             config.label
+          }"></tangy-input>
+          <tangy-input name="hintText" label="Hint Text" value="${
+            config.hintText
           }"></tangy-input>
           <tangy-input name="tangy_if" label="Show if" value="${
             config.tangyIf

--- a/widget/tangy-date-widget.js
+++ b/widget/tangy-date-widget.js
@@ -39,7 +39,7 @@ class TangyDateWidget extends TangyBaseWidget {
       <tangy-input 
         name="${config.name}"
         label="${config.label}"
-        hintText="${config.hintText}"
+        hint-text="${config.hintText}"
         type="date"
         ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
         ${config.required ? 'required' : ''}
@@ -115,6 +115,7 @@ class TangyDateWidget extends TangyBaseWidget {
       label: formEl.response.items[0].inputs.find(
         input => input.name === 'label'
       ).value,
+      hintText: formEl.values.hintText,
       required:
         formEl.response.items[0].inputs.find(input => input.name === 'required')
           .value === 'on'

--- a/widget/tangy-date-widget.js
+++ b/widget/tangy-date-widget.js
@@ -12,6 +12,7 @@ class TangyDateWidget extends TangyBaseWidget {
     return {
       name: '',
       label: '',
+      hintText: '',
       type: 'date',
       required: false,
       disabled: false,
@@ -38,6 +39,7 @@ class TangyDateWidget extends TangyBaseWidget {
       <tangy-input 
         name="${config.name}"
         label="${config.label}"
+        hintText="${config.hintText}"
         type="date"
         ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         ${config.required ? 'required' : ''}
@@ -52,7 +54,7 @@ class TangyDateWidget extends TangyBaseWidget {
       <table>
         <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
         <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
-        <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+        <tr><td><strong>Hint:</strong></td><td>${config.hintText}</td></tr>
         <tr><td><strong>Type:</strong></td><td>${config.type}</td></tr>
         <tr><td><strong>Error Message:</strong></td><td>${
           config.errorMessage
@@ -86,6 +88,9 @@ class TangyDateWidget extends TangyBaseWidget {
         }" required></tangy-input>
         <tangy-input name="label" label="Label" value="${
           config.label
+        }"></tangy-input>
+        <tangy-input name="hintText" label="Hint Text" value="${
+          config.hintText
         }"></tangy-input>
         <tangy-input name="tangy_if" label="Show if" value="${
           config.tangyIf

--- a/widget/tangy-eftouch-widget.js
+++ b/widget/tangy-eftouch-widget.js
@@ -15,6 +15,7 @@ class TangyEftouchWidget extends TangyBaseWidget {
     return {
       name: '',
       label: '',
+      hintText: '',
       optionsMarkup: '',
       inputSound: '',
       transitionSound: '',
@@ -43,6 +44,7 @@ class TangyEftouchWidget extends TangyBaseWidget {
       <tangy-eftouch
         name="${config.name}"
         label="${config.label}"
+        hintText="${config.hintText}"
         input-sound="${config.inputSound}"
         transition-sound="${config.transitionSound}"
         transition-delay="${config.transitionDelay}"
@@ -77,6 +79,9 @@ class TangyEftouchWidget extends TangyBaseWidget {
           }" required></tangy-input>
           <tangy-input name="label" label="Label" value="${
             config.label
+          }"></tangy-input>
+          <tangy-input name="hintText" label="Hint Text" value="${
+            config.hintText
           }"></tangy-input>
           <tangy-input name="input-sound" label="Input sound" value="${
             config.inputSound
@@ -126,7 +131,7 @@ class TangyEftouchWidget extends TangyBaseWidget {
     <table>
     <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
     <tr><td><strong>Variable Label:</strong></td><td>${config.label}</td></tr>
-    <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+    <tr><td><strong>Hint:</strong></td><td>${config.hintText}</td></tr>
     <tr><td><strong>Input Sound:</strong></td><td>${config.inputSound}</td></tr>
     <tr><td><strong>Transition Sound:</strong></td><td>${
       config.transitionSound

--- a/widget/tangy-email-widget.js
+++ b/widget/tangy-email-widget.js
@@ -39,7 +39,7 @@ class TangyEmailWidget extends TangyBaseWidget {
       <tangy-input 
         name="${config.name}"
         label="${config.label}"
-        hintText="${config.hintText}"
+        hint-text="${config.hintText}"
         type="email"
         ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
         ${config.required ? 'required' : ''}
@@ -113,6 +113,7 @@ class TangyEmailWidget extends TangyBaseWidget {
       label: formEl.response.items[0].inputs.find(
         input => input.name === 'label'
       ).value,
+      hintText: formEl.values.hintText,
       required:
         formEl.response.items[0].inputs.find(input => input.name === 'required')
           .value === 'on'

--- a/widget/tangy-email-widget.js
+++ b/widget/tangy-email-widget.js
@@ -12,6 +12,7 @@ class TangyEmailWidget extends TangyBaseWidget {
     return {
       name: '',
       label: '',
+      hintText: '',
       type: 'email',
       required: false,
       disabled: false,
@@ -38,6 +39,7 @@ class TangyEmailWidget extends TangyBaseWidget {
       <tangy-input 
         name="${config.name}"
         label="${config.label}"
+        hintText="${config.hintText}"
         type="email"
         ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         ${config.required ? 'required' : ''}
@@ -52,7 +54,7 @@ class TangyEmailWidget extends TangyBaseWidget {
     <table>
       <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
-      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hintText}</td></tr>
       <tr><td><strong>Type:</strong></td><td>${config.type}</td></tr>
       <tr><td><strong>Error Message:</strong></td><td>${
         config.errorMessage
@@ -84,6 +86,9 @@ class TangyEmailWidget extends TangyBaseWidget {
         }" required></tangy-input>
         <tangy-input name="label" label="Label" value="${
           config.label
+        }"></tangy-input>
+        <tangy-input name="hintText" label="Hint Text" value="${
+          config.hintText
         }"></tangy-input>
         <tangy-input name="tangy_if" label="Show if" value="${
           config.tangyIf

--- a/widget/tangy-gps-widget.js
+++ b/widget/tangy-gps-widget.js
@@ -36,12 +36,8 @@ class TangyGpsWidget extends TangyBaseWidget {
     return `
       <tangy-gps 
         name="${config.name}"
-<<<<<<< HEAD
-        hintText="${config.hintText}"
-        ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
-=======
+        hint-text="${config.hintText}"
         ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
->>>>>>> origin/master
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
@@ -98,7 +94,7 @@ class TangyGpsWidget extends TangyBaseWidget {
         }" required></tangy-input>
         <tangy-input name="hintText" label="Hint Text" value="${
           config.hintText
-        }" required></tangy-input>
+        }"></tangy-input>
         <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf.replace(/"/g, '&quot;')}"></tangy-input>
         <tangy-checkbox name="required" ${
           config.required ? 'value="on"' : ''
@@ -124,6 +120,7 @@ class TangyGpsWidget extends TangyBaseWidget {
           .value === 'on'
           ? true
           : false,
+      hintText: formEl.values.hintText,
       hidden:
         formEl.response.items[0].inputs.find(input => input.name === 'hidden')
           .value === 'on'

--- a/widget/tangy-gps-widget.js
+++ b/widget/tangy-gps-widget.js
@@ -11,6 +11,7 @@ class TangyGpsWidget extends TangyBaseWidget {
   get defaultConfig() {
     return {
       name: '',
+      hintText: '',
       required: false,
       disabled: false,
       hidden: false,
@@ -35,6 +36,7 @@ class TangyGpsWidget extends TangyBaseWidget {
     return `
       <tangy-gps 
         name="${config.name}"
+        hintText="${config.hintText}"
         ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
@@ -47,7 +49,7 @@ class TangyGpsWidget extends TangyBaseWidget {
    
     <table>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
-      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hintText}</td></tr>
       <tr><td><strong>Hide Accuracy Distance:</strong></td><td>${
         config.hideAccuracyDistance
       }</td></tr>
@@ -89,6 +91,9 @@ class TangyGpsWidget extends TangyBaseWidget {
       <tangy-form-item>
         <tangy-input name="name" label="Variable name" value="${
           config.name
+        }" required></tangy-input>
+        <tangy-input name="hintText" label="Hint Text" value="${
+          config.hintText
         }" required></tangy-input>
         <tangy-input name="tangy_if" label="Show if" value="${
           config.tangyIf

--- a/widget/tangy-location-widget.js
+++ b/widget/tangy-location-widget.js
@@ -42,7 +42,7 @@ class TangyLocationWidget extends TangyBaseWidget {
     return `
       <tangy-location 
         name="${config.name}"
-        hintText="${config.hintText}"
+        hint-text="${config.hintText}"
         ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
@@ -87,7 +87,7 @@ class TangyLocationWidget extends TangyBaseWidget {
         }" required></tangy-input>
         <tangy-input name="hintText" label="Hint Text" value="${
           config.hintText
-        }" required></tangy-input>
+        }"></tangy-input>
         <tangy-checkbox name="filterByGlobal" ${
           config.filterByGlobal ? 'value="on"' : ''
         }>Filter by locations in the user profile?</tangy-checkbox>
@@ -125,6 +125,7 @@ class TangyLocationWidget extends TangyBaseWidget {
           .value === 'on'
           ? true
           : false,
+      hintText: formEl.values.hintText,
       hidden:
         formEl.response.items[0].inputs.find(input => input.name === 'hidden')
           .value === 'on'

--- a/widget/tangy-location-widget.js
+++ b/widget/tangy-location-widget.js
@@ -12,6 +12,7 @@ class TangyLocationWidget extends TangyBaseWidget {
   get defaultConfig() {
     return {
       name: '',
+      hintText: '',
       required: false,
       disabled: false,
       hidden: false,
@@ -41,6 +42,7 @@ class TangyLocationWidget extends TangyBaseWidget {
     return `
       <tangy-location 
         name="${config.name}"
+        hintText="${config.hintText}"
         ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
@@ -61,7 +63,7 @@ class TangyLocationWidget extends TangyBaseWidget {
         config.showLevels
       }</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
-      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hintText}</td></tr>
       <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
       <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
       <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
@@ -82,6 +84,9 @@ class TangyLocationWidget extends TangyBaseWidget {
       <tangy-form-item>
         <tangy-input name="name" label="Variable name" value="${
           config.name
+        }" required></tangy-input>
+        <tangy-input name="hintText" label="Hint Text" value="${
+          config.hintText
         }" required></tangy-input>
         <tangy-checkbox name="filterByGlobal" ${
           config.filterByGlobal ? 'value="on"' : ''

--- a/widget/tangy-number-widget.js
+++ b/widget/tangy-number-widget.js
@@ -12,6 +12,7 @@ class TangyNumberWidget extends TangyBaseWidget {
     return {
       name: '',
       label: '',
+      hintText: '',
       type: 'text',
       required: false,
       disabled: false,
@@ -41,6 +42,7 @@ class TangyNumberWidget extends TangyBaseWidget {
       <tangy-input 
         name="${config.name}"
         label="${config.label}"
+        hintText="${config.hintText}"
         type="number"
         ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         allowed-pattern="${config.allowedPattern}"
@@ -63,7 +65,7 @@ class TangyNumberWidget extends TangyBaseWidget {
       <table>
       <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
-      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hintText}</td></tr>
       <tr><td><strong>Type:</strong></td><td>${config.type}</td></tr>
       <tr><td><strong>Error Message:</strong></td><td>${
         config.errorMessage
@@ -90,6 +92,9 @@ class TangyNumberWidget extends TangyBaseWidget {
         }" required></tangy-input>
         <tangy-input name="label" label="Label" value="${
           config.label
+        }"></tangy-input>
+        <tangy-input name="hintText" label="Hint Text" value="${
+          config.hintText
         }"></tangy-input>
         <tangy-input name="allowed_pattern" label="Allowed pattern" value="${
           config.allowedPattern

--- a/widget/tangy-number-widget.js
+++ b/widget/tangy-number-widget.js
@@ -42,7 +42,7 @@ class TangyNumberWidget extends TangyBaseWidget {
       <tangy-input 
         name="${config.name}"
         label="${config.label}"
-        hintText="${config.hintText}"
+        hint-text="${config.hintText}"
         type="number"
         ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
         allowed-pattern="${config.allowedPattern}"
@@ -132,6 +132,7 @@ class TangyNumberWidget extends TangyBaseWidget {
         .value,
       max: formEl.response.items[0].inputs.find(input => input.name === 'max')
         .value,
+      hintText: formEl.values.hintText,
       required:
         formEl.response.items[0].inputs.find(input => input.name === 'required')
           .value === 'on'

--- a/widget/tangy-radio-buttons-widget.js
+++ b/widget/tangy-radio-buttons-widget.js
@@ -14,6 +14,7 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
     return {
       name: '',
       label: '',
+      hintText: '',
       options: [],
       required: false,
       disabled: false,
@@ -44,6 +45,7 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
       <tangy-radio-buttons
         name="${config.name}"
         label="${config.label}"
+        hintText="${config.hintText}"
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
@@ -68,7 +70,7 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
     <table>
       <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
-      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hintText}</td></tr>
       <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
       <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
       <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
@@ -94,6 +96,9 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
           }" required></tangy-input>
           <tangy-input name="label" label="Label" value="${
             config.label
+          }"></tangy-input>
+          <tangy-input name="hintText" label="Hint Text" value="${
+            config.hintText
           }"></tangy-input>
           <tangy-input name="tangy_if" label="Show if" value="${
             config.tangyIf

--- a/widget/tangy-radio-buttons-widget.js
+++ b/widget/tangy-radio-buttons-widget.js
@@ -45,11 +45,8 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
       <tangy-radio-buttons
         name="${config.name}"
         label="${config.label}"
-<<<<<<< HEAD
-        hintText="${config.hintText}"
-=======
+        hint-text="${config.hintText}"
         ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
->>>>>>> origin/master
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
@@ -177,6 +174,7 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
       name: formEl.values.name,
       label: formEl.values.label,
       required: formEl.values.required === 'on' ? true : false,
+      hintText: formEl.values.hintText,
       hidden: formEl.values.hidden === 'on' ? true : false,
       disabled: formEl.values.disabled === 'on' ? true : false,
       options: formEl.values.options.map(item =>

--- a/widget/tangy-select-widget.js
+++ b/widget/tangy-select-widget.js
@@ -14,6 +14,7 @@ class TangySelectWidget extends TangyBaseWidget {
     return {
       name: '',
       label: '',
+      hintText: '',
       options: [],
       required: false,
       disabled: false,
@@ -44,6 +45,7 @@ class TangySelectWidget extends TangyBaseWidget {
       <tangy-select
         name="${config.name}"
         label="${config.label}"
+        hintText="${config.hintText}"
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
@@ -71,7 +73,7 @@ class TangySelectWidget extends TangyBaseWidget {
         config.secondaryLabel
       }</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
-      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hintText}</td></tr>
       <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
       <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
       <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
@@ -97,6 +99,9 @@ class TangySelectWidget extends TangyBaseWidget {
           }" required></tangy-input>
           <tangy-input name="label" label="Label" value="${
             config.label
+          }"></tangy-input>
+          <tangy-input name="hintText" label="Hint Text" value="${
+            config.hintText
           }"></tangy-input>
           <tangy-input name="tangy_if" label="Show if" value="${
             config.tangyIf

--- a/widget/tangy-select-widget.js
+++ b/widget/tangy-select-widget.js
@@ -45,11 +45,8 @@ class TangySelectWidget extends TangyBaseWidget {
       <tangy-select
         name="${config.name}"
         label="${config.label}"
-<<<<<<< HEAD
-        hintText="${config.hintText}"
-=======
+        hint-text="${config.hintText}"
         ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
->>>>>>> origin/master
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
@@ -180,6 +177,7 @@ class TangySelectWidget extends TangyBaseWidget {
       name: formEl.values.name,
       label: formEl.values.label,
       required: formEl.values.required === 'on' ? true : false,
+      hintText: formEl.values.hintText,
       hidden: formEl.values.hidden === 'on' ? true : false,
       disabled: formEl.values.disabled === 'on' ? true : false,
       options: formEl.values.options.map(item =>

--- a/widget/tangy-text-generic-widget.js
+++ b/widget/tangy-text-generic-widget.js
@@ -72,6 +72,7 @@ class TangyTextGenericWidget extends TangyBaseWidget {
       ...config,
       name: formEl.response.items[0].inputs.find(input => input.name === 'name').value,
       label: formEl.response.items[0].inputs.find(input => input.name === 'label').value,
+      hintText: formEl.values.hintText,
       required: formEl.response.items[0].inputs.find(input => input.name === 'required').value === 'on' ? true : false,
       hidden: formEl.response.items[0].inputs.find(input => input.name === 'hidden').value === 'on' ? true : false,
       disabled: formEl.response.items[0].inputs.find(input => input.name === 'disabled').value === 'on' ? true : false,

--- a/widget/tangy-text-widget.js
+++ b/widget/tangy-text-widget.js
@@ -11,6 +11,7 @@ class TangyTextWidget extends TangyBaseWidget {
     return {
       name: '',
       label: '',
+      hintText: '',
       type: 'text',
       required: false,
       disabled: false,
@@ -38,6 +39,7 @@ class TangyTextWidget extends TangyBaseWidget {
       <tangy-input 
         name="${config.name}"
         label="${config.label}"
+        hintText="${config.hintText}"
         type="text"
         ${config.tangyIf === '' ? '' : `tangy-if="${config.tangyIf}"`}
         allowed-pattern="${config.allowedPattern}"
@@ -54,7 +56,7 @@ class TangyTextWidget extends TangyBaseWidget {
     <table>
       <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
-      <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+      <tr><td><strong>Hint:</strong></td><td>${config.hintText}</td></tr>
       <tr><td><strong>Type:</strong></td><td>${config.type}</td></tr>
       <tr><td><strong>Error Message:</strong></td><td>${
         config.errorMessage
@@ -87,6 +89,9 @@ class TangyTextWidget extends TangyBaseWidget {
         }" required></tangy-input>
         <tangy-input name="label" label="Label" value="${
           config.label
+        }"></tangy-input>
+        <tangy-input name="hintText" label="Hint Text" value="${
+          config.hintText
         }"></tangy-input>
         <tangy-input name="allowed_pattern" label="Allowed pattern" value="${
           config.allowedPattern

--- a/widget/tangy-text-widget.js
+++ b/widget/tangy-text-widget.js
@@ -39,7 +39,7 @@ class TangyTextWidget extends TangyBaseWidget {
       <tangy-input 
         name="${config.name}"
         label="${config.label}"
-        hintText="${config.hintText}"
+        hint-text="${config.hintText}"
         type="text"
         ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
         allowed-pattern="${config.allowedPattern}"
@@ -119,6 +119,7 @@ class TangyTextWidget extends TangyBaseWidget {
       label: formEl.response.items[0].inputs.find(
         input => input.name === 'label'
       ).value,
+      hintText: formEl.values.hintText,
       required:
         formEl.response.items[0].inputs.find(input => input.name === 'required')
           .value === 'on'

--- a/widget/tangy-time-widget.js
+++ b/widget/tangy-time-widget.js
@@ -39,6 +39,7 @@ class TangyTimeWidget extends TangyBaseWidget {
         name="${config.name}"
         label="${config.label}"
         type="time"
+        hint-text="${config.hintText}"
         ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
@@ -82,6 +83,9 @@ class TangyTimeWidget extends TangyBaseWidget {
         <tangy-input name="label" label="Label" value="${
           config.label
         }"></tangy-input>
+        <tangy-input name="hintText" label="Hint Text" value="${
+          config.hintText
+        }"></tangy-input>
         <tangy-input name="tangy_if" label="Show if" value="${config.tangyIf.replace(/"/g, '&quot;')}"></tangy-input>
         <tangy-checkbox name="required" ${
           config.required ? 'value="on"' : ''
@@ -110,6 +114,7 @@ class TangyTimeWidget extends TangyBaseWidget {
           .value === 'on'
           ? true
           : false,
+      hintText: formEl.values.hintText,
       hidden:
         formEl.response.items[0].inputs.find(input => input.name === 'hidden')
           .value === 'on'

--- a/widget/tangy-timed-widget.js
+++ b/widget/tangy-timed-widget.js
@@ -166,6 +166,7 @@ class TangyTimedWidget extends TangyBaseWidget {
       name: formEl.values.name,
       label: formEl.values.label,
       autoStop: formEl.values.autoStop,
+      hintText: formEl.values.hintText,
       required: formEl.values.required === 'on' ? true : false,
       hidden: formEl.values.hidden === 'on' ? true : false,
       disabled: formEl.values.disabled === 'on' ? true : false,

--- a/widget/tangy-timed-widget.js
+++ b/widget/tangy-timed-widget.js
@@ -15,6 +15,7 @@ class TangyTimedWidget extends TangyBaseWidget {
     return {
       name: '',
       label: '',
+      hintText: '',
       options: [],
       required: false,
       disabled: false,
@@ -45,6 +46,7 @@ class TangyTimedWidget extends TangyBaseWidget {
       <tangy-timed
         name="${config.name}"
         label="${config.label}"
+        hintText="${config.hintText}"
         ${config.required ? 'required' : ''}
         ${config.disabled ? 'disabled' : ''}
         ${config.hidden ? 'hidden' : ''}
@@ -69,7 +71,7 @@ class TangyTimedWidget extends TangyBaseWidget {
    
     <table>
     <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
-    <tr><td><strong>Hint:</strong></td><td>${config.hint}</td></tr>
+    <tr><td><strong>Hint:</strong></td><td>${config.hintText}</td></tr>
     <tr><td><strong>Duration:</strong></td><td>${config.duration}</td></tr>
     <tr><td><strong>Mode:</strong></td><td>${config.mode}</td></tr>
       <tr><td><strong>Columns:</strong></td><td>${config.columns}</td></tr>
@@ -101,6 +103,9 @@ class TangyTimedWidget extends TangyBaseWidget {
           }" required></tangy-input>
           <tangy-input name="label" label="Label" value="${
             config.label
+          }"></tangy-input>
+          <tangy-input name="hintText" label="Hint Text" value="${
+            config.hintText
           }"></tangy-input>
           <tangy-input name="tangy_if" label="Show if" value="${
             config.tangyIf


### PR DESCRIPTION
## Problem/Feature
* Allow editors to edit the`hint-text` attribute
* Closes Tangerine-Community/Tangerine#1279

## Approach/Solution

* exposed the `hintText` property to the editor interface for each of the corresponding elements