### PR TITLE
Add common attributes helpers for widgets handling attributes like name, class, show-if, etc.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -76,16 +76,12 @@
                   "
                 >
                   <template>
-                    <h3>Checkboxes</h3>
-                    <!--<p>-->
                       <tangy-checkbox name="checkbox_1">This checkbox is not required.</tangy-checkbox>
                       <tangy-checkbox name="checkbox_2" required>This checkbox is required.</tangy-checkbox>
                       <tangy-checkbox name="checkbox_3" required>This checkbox is disabled, but if enabled, it is then also required.</tangy-checkbox>
                       <tangy-checkbox name="checkbox_4">Check this checkbox to enable the disabled checkbox.</tangy-checkbox>
                       <tangy-checkbox name="checkbox_5" required>This checkbox is hidden, but if show, it is also required.</tangy-checkbox>
                       <tangy-checkbox name="checkbox_6">Check this checkbox to show the hidden checkbox.</tangy-checkbox>
-                    <!--</p>-->
-                    <h3>Checkbox Groups</h3>
                     <tangy-checkboxes
                       name="checkbox_group_1"
                       label="This is a checkbox group.">

--- a/tangy-base-widget.js
+++ b/tangy-base-widget.js
@@ -45,7 +45,8 @@ class TangyBaseWidget extends PolymerElement {
 
   get defaultConfig() {
     return {
-      ...this.defaultConfigCommonAttributes()
+      ...this.defaultConfigCommonAttributes(),
+      ...this.defaultConfigLabelAttributes()
     }
   }
 
@@ -71,11 +72,12 @@ class TangyBaseWidget extends PolymerElement {
   }
 
 
-  // Convert this.innerHTML to configuration.
   upcast(config, element) {
     return { 
       ...config,
-      ...this.upcastCommonAttributes()
+      ...this.upcastCommonAttributes(config, element),
+      ...this.upcastLabelAttributes(config, element),
+      ...this.getProps()
     }
   }
 
@@ -91,6 +93,9 @@ class TangyBaseWidget extends PolymerElement {
         style: element.hasAttribute('style')
           ? element.getAttribute('style')
           : '',
+        required: element.hasAttribute('required') ? true : false,
+        hidden: element.hasAttribute('hidden') ? true : false,
+        disabled: element.hasAttribute('disabled') ? true : false,
         showIf: (
           element.hasAttribute('show-if')
             ? element.getAttribute('show-if')
@@ -120,7 +125,10 @@ class TangyBaseWidget extends PolymerElement {
   }
   // Convert configuration to HTML.
   downcast(config) {
-    return `<tangy-base ${this.downcastCommonAttributes(config)}></tangy-base>`
+    return `<tangy-base 
+        ${this.downcastCommonAttributes(config)}
+        ${this.downcastLabelAttributes(config)}
+      ></tangy-base>`
   }
 
   downcastCommonAttributes(config) {
@@ -157,11 +165,11 @@ class TangyBaseWidget extends PolymerElement {
 
   // Return markup for use when in edit mode.
   renderEdit(config) {
-    return `<h2>Add Text Input</h2>
+    return `
       <tangy-form id="form">
         <tangy-form-item id='item'>
           ${this.renderEditCommonAttributes(config)}
-          ...custom attributes here...
+          ${this.renderEditLabelAttributes(config)}
         </tangy-form-item>
       </tangy-form>
     `
@@ -212,7 +220,6 @@ class TangyBaseWidget extends PolymerElement {
       <tangy-input
         name="label"
         inner-label="Label"
-        hint-text="Enter the Question or Statement Text"
         value="${
           config.label
         }">
@@ -236,8 +243,8 @@ class TangyBaseWidget extends PolymerElement {
   // On save of edit form, return updated _config.
   onSubmit(config, formEl) {
     return { 
-      ...config, 
-      ...this.onSubmitCommonAttributes(config, formEl)
+      ...this.onSubmitCommonAttributes(config, formEl),
+      ...this.onSubmitLabelAttributes(config, formEl)
     }
   }
 

--- a/tangy-base-widget.js
+++ b/tangy-base-widget.js
@@ -62,6 +62,15 @@ class TangyBaseWidget extends PolymerElement {
     }
   }
 
+  defaultConfigLabelAttributes() {
+    return {
+      label: '',
+      hintText: '',
+      errorMessage: ''
+    }
+  }
+
+
   // Convert this.innerHTML to configuration.
   upcast(config, element) {
     return { 
@@ -96,6 +105,19 @@ class TangyBaseWidget extends PolymerElement {
     }
   }
 
+  upcastLabelAttributes(config, element) {
+    return {
+      label: element.hasAttribute('label')
+        ? element.getAttribute('label')
+        : '',
+      errorMessage: element.hasAttribute('error-message')
+        ? element.getAttribute('error-message')
+        : '',
+      hintText: element.hasAttribute('hint-text')
+        ? element.getAttribute('hint-text')
+        : ''
+    }
+  }
   // Convert configuration to HTML.
   downcast(config) {
     return `<tangy-base ${this.downcastCommonAttributes(config)}></tangy-base>`
@@ -113,6 +135,14 @@ class TangyBaseWidget extends PolymerElement {
       ${config.required ? 'required' : ''}
       ${config.disabled ? 'disabled' : ''}
       ${config.hidden ? 'hidden' : ''}
+  `
+  }
+
+   downcastLabelAttributes(config) {
+    return `
+      label="${config.label}"
+      error-message="${config.errorMessage}"
+      hint-text="${config.hintText}"
   `
   }
   
@@ -177,6 +207,32 @@ class TangyBaseWidget extends PolymerElement {
     `
   }
 
+  renderEditLabelAttributes(config) {
+    return `
+      <tangy-input
+        name="label"
+        inner-label="Label"
+        hint-text="Enter the Question or Statement Text"
+        value="${
+          config.label
+        }">
+      </tangy-input>
+      <tangy-input
+        name="hint-text"
+        inner-label="Hint text"
+        value="${
+          config.hintText
+        }">
+      </tangy-input>
+      <tangy-input
+        name="error-message"
+        inner-label="Error message"
+        value="${
+          config.errorMessage
+        }">
+      </tangy-input>
+    `
+  }
   // On save of edit form, return updated _config.
   onSubmit(config, formEl) {
     return { 
@@ -213,6 +269,16 @@ class TangyBaseWidget extends PolymerElement {
     }
   }
 
+  onSubmitLabelAttributes(config, formEl) {
+    return { 
+      label: formEl.response.items[0].inputs.find(input => input.name === 'label')
+        .value,
+       errorMessage: formEl.response.items[0].inputs.find(input => input.name === 'error-message')
+        .value,
+       hintText: formEl.response.items[0].inputs.find(input => input.name === 'hint-text')
+        .value
+    }
+  }
   editResponse(config) {
     return false
   }

--- a/tangy-base-widget.js
+++ b/tangy-base-widget.js
@@ -136,8 +136,6 @@ class TangyBaseWidget extends PolymerElement {
       name="${config.name}"
       class="${config.class}"
       style="${config.style}"
-      error-message="${config.errorMessage}"
-      invalid-message="${config.errorMessage}"
       ${config.showIf === "" ? "" : `tangy-if="${config.showIf.replace(/"/g, '&quot;')}"`}
       ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
       ${config.required ? 'required' : ''}
@@ -150,6 +148,7 @@ class TangyBaseWidget extends PolymerElement {
     return `
       label="${config.label}"
       error-message="${config.errorMessage}"
+      invalid-message="${config.errorMessage}"
       hint-text="${config.hintText}"
   `
   }
@@ -184,6 +183,19 @@ class TangyBaseWidget extends PolymerElement {
         value="${config.name}"
         hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
         required>
+      </tangy-input>
+      <tangy-input 
+        name="class" 
+        inner-label="CSS Class"
+        value="${config.class}"
+        hint-text="Enter CSS classes this element may belong to."
+        >
+      </tangy-input>
+      <tangy-input
+        name="style"
+        inner-label="CSS Style"
+        hint-text="Enter CSS for this element."
+        value="${config.style.replace(/"/g, '&quot;')}">
       </tangy-input>
       <tangy-input
         name="show_if"
@@ -250,8 +262,9 @@ class TangyBaseWidget extends PolymerElement {
 
   onSubmitCommonAttributes(config, formEl) {
     return { 
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
-        .value,
+      name: formEl.response.items[0].inputs.find(input => input.name === 'name').value,
+      style: formEl.response.items[0].inputs.find(input => input.name === 'style').value,
+      class: formEl.response.items[0].inputs.find(input => input.name === 'class').value,
       required:
         formEl.response.items[0].inputs.find(input => input.name === 'required')
           .value === 'on'

--- a/tangy-form-editor-add-input.js
+++ b/tangy-form-editor-add-input.js
@@ -61,6 +61,7 @@ class TangyFormEditorAddInput extends PolymerElement {
             <mwc-button icon="text_fields" on-click="addThis"><span id="tangy-text-widget">Text</span></mwc-button><br>
             <mwc-button icon="timer" on-click="addThis"><span id="tangy-time-widget">Time</span></mwc-button><br>
             <mwc-button icon="looks_one" on-click="addThis"><span id="tangy-number-widget">Number</span></mwc-button><br>
+            <mwc-button icon="email" on-click="addThis"><span id="tangy-email-widget">Email</span></mwc-button><br>
           </div>
         </div>
         <div>

--- a/test/tangy-acasi-widget_test.html
+++ b/test/tangy-acasi-widget_test.html
@@ -37,7 +37,6 @@
       suite('tangy-acasi-widget', () => {
         test('should open blank with defaults', () => {
           const element = fixture('BlankFixture')
-          debugger;
           assert.equal(element._config.hasOwnProperty('name'), true)
           assert.equal(element._config.hasOwnProperty('required'), true)
           assert.equal(element._config.hasOwnProperty('disabled'), true)

--- a/test/tangy-box-widget_test.html
+++ b/test/tangy-box-widget_test.html
@@ -68,14 +68,13 @@
           const element = fixture('BlankFixture')
           assert.equal(element._config.hasOwnProperty('name'), true)
           assert.equal(element._config.hasOwnProperty('hidden'), true)
-          assert.equal(element._config.hasOwnProperty('tangyIf'), true)
+          assert.equal(element._config.hasOwnProperty('showIf'), true)
           assert.equal(element._config.hasOwnProperty('htmlCode'), true)
         })
         test('should resume', () => {
           const element = fixture('ResumeFixture')
           assert.equal(element._config.name, 'Summary')
           assert.equal(element._config.hidden, true)
-          // assert.equal(element._config.tangyIf, `console.log('test')`)
           assert.equal(element._config.htmlCode, `<p>Thank you for taking our survey. You may close the book.</p>`)
         })
         test('should resume and save with edits', () => {

--- a/test/tangy-checkbox-widget_test.html
+++ b/test/tangy-checkbox-widget_test.html
@@ -21,12 +21,11 @@
         <tangy-checkbox-widget>
           <tangy-checkbox
             name="input1"
-            label="Input 1"
             required
             hidden
             disabled
             tangy-if="console.log('test')"
-          </tangy-checkbox>
+          >Input 1</tangy-checkbox>
         </tangy-checkbox-widget>
       </template>
     </test-fixture>
@@ -45,7 +44,7 @@
           assert.equal(element._config.hasOwnProperty('disabled'), true)
           assert.equal(element._config.hasOwnProperty('hidden'), true)
           assert.equal(element._config.hasOwnProperty('label'), true)
-          assert.equal(element._config.hasOwnProperty('tangyIf'), true)
+          assert.equal(element._config.hasOwnProperty('showIf'), true)
         })
         test('should resume', () => {
           const element = fixture('ResumeFixture')
@@ -54,7 +53,7 @@
           assert.equal(element._config.required, true)
           assert.equal(element._config.hidden, true)
           assert.equal(element._config.disabled, true)
-          assert.equal(element._config.tangyIf, `console.log('test')`)
+          assert.equal(element._config.showIf, `console.log('test')`)
         })
         test('should resume and save with edits', () => {
           const element = fixture('ResumeFixture')

--- a/test/tangy-consent-widget_test.html
+++ b/test/tangy-consent-widget_test.html
@@ -36,7 +36,7 @@
           assert.equal(element._config.hasOwnProperty('required'), true)
           assert.equal(element._config.hasOwnProperty('disabled'), true)
           assert.equal(element._config.hasOwnProperty('hidden'), true)
-          assert.equal(element._config.hasOwnProperty('tangyIf'), true)
+          assert.equal(element._config.hasOwnProperty('showIf'), true)
         })
         test('should resume', () => {
           const element = fixture('ResumeFixture')

--- a/test/tangy-date-widget_test.html
+++ b/test/tangy-date-widget_test.html
@@ -42,7 +42,7 @@
           assert.equal(element._config.hasOwnProperty('disabled'), true)
           assert.equal(element._config.hasOwnProperty('hidden'), true)
           assert.equal(element._config.hasOwnProperty('label'), true)
-          assert.equal(element._config.hasOwnProperty('tangyIf'), true)
+          assert.equal(element._config.hasOwnProperty('showIf'), true)
           assert.equal(element._config.hasOwnProperty('allowedPattern'), true)
           assert.equal(element._config.hasOwnProperty('min'), true)
           assert.equal(element._config.hasOwnProperty('max'), true)
@@ -55,7 +55,7 @@
           assert.equal(element._config.required, true)
           assert.equal(element._config.hidden, false)
           assert.equal(element._config.disabled, false)
-          assert.equal(element._config.tangyIf, `console.log('test')`)
+          assert.equal(element._config.showIf, `console.log('test')`)
           assert.equal(element._config.type, `date`)
         })
         test('should resume and save with edits', () => {

--- a/test/tangy-gps-widget_test.html
+++ b/test/tangy-gps-widget_test.html
@@ -36,7 +36,7 @@
           assert.equal(element._config.hasOwnProperty('required'), true)
           assert.equal(element._config.hasOwnProperty('disabled'), true)
           assert.equal(element._config.hasOwnProperty('hidden'), true)
-          assert.equal(element._config.hasOwnProperty('tangyIf'), true)
+          assert.equal(element._config.hasOwnProperty('showIf'), true)
         })
         test('should resume', () => {
           const element = fixture('ResumeFixture')

--- a/test/tangy-location-widget_test.html
+++ b/test/tangy-location-widget_test.html
@@ -39,7 +39,7 @@
           assert.equal(element._config.hasOwnProperty('required'), true)
           assert.equal(element._config.hasOwnProperty('disabled'), true)
           assert.equal(element._config.hasOwnProperty('hidden'), true)
-          assert.equal(element._config.hasOwnProperty('tangyIf'), true)
+          assert.equal(element._config.hasOwnProperty('showIf'), true)
           assert.equal(element._config.hasOwnProperty('showMetaData'), true)
           assert.equal(element._config.hasOwnProperty('metaDataTemplate'), true)
         })

--- a/test/tangy-text-widget_test.html
+++ b/test/tangy-text-widget_test.html
@@ -44,7 +44,7 @@
           assert.equal(element._config.hasOwnProperty('disabled'), true)
           assert.equal(element._config.hasOwnProperty('hidden'), true)
           assert.equal(element._config.hasOwnProperty('label'), true)
-          assert.equal(element._config.hasOwnProperty('tangyIf'), true)
+          assert.equal(element._config.hasOwnProperty('showIf'), true)
           assert.equal(element._config.hasOwnProperty('allowedPattern'), true)
           assert.equal(element._config.hasOwnProperty('min'), true)
           assert.equal(element._config.hasOwnProperty('max'), true)
@@ -57,7 +57,7 @@
           assert.equal(element._config.required, true)
           assert.equal(element._config.hidden, true)
           assert.equal(element._config.disabled, true)
-          assert.equal(element._config.tangyIf, `console.log('test')`)
+          assert.equal(element._config.showIf, `console.log('test')`)
           assert.equal(element._config.type, `text`)
         })
         test('should resume and save with edits', () => {

--- a/widget/tangy-acasi-widget.js
+++ b/widget/tangy-acasi-widget.js
@@ -4,21 +4,18 @@ import 'tangy-form/input/tangy-select.js';
 import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyAcasiWidget extends TangyBaseWidget {
+
   get claimElement() {
     return 'tangy-acasi';
   }
+
   get defaultConfig() {
     return {
-      name: '',
+      ...this.defaultConfigCommonAttributes(),
       label: '',
       hintText: '',
       type: 'text',
-      required: false,
-      disabled: false,
-      hidden: false,
       allowedPattern: '',
-      tangyIf: '',
-      validIf: '',
       images:'./assets/images/never.png,./assets/images/once.png,./assets/images/few.png,./assets/images/many.png,./assets/images/dont_know.png',
       touchsrc:'./assets/sounds/never_Eng.mp3,./assets/sounds/once_Eng.mp3,./assets/sounds/fewtimes_Eng.mp3,./assets/sounds/manytimes_Eng.mp3,./assets/sounds/noresponse_Eng.mp3',
       introsrc:'',
@@ -31,17 +28,12 @@ class TangyAcasiWidget extends TangyBaseWidget {
     return {
       ...config,
       ...element.getProps(),
+      ...this.upcastCommonAttributes(config, element),
       ...{
         images: element.getAttribute('images'),
         touchsrc: element.getAttribute('touchsrc'),
         introsrc: element.hasAttribute('introsrc') ? element.getAttribute('introsrc'): '',
         transitionsrc: element.getAttribute('transitionsrc'),
-        tangyIf: element.hasAttribute('tangy-if')
-          ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-          : '',
-        validIf: element.hasAttribute('valid-if')
-          ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-          : ''
       }
     };
   }
@@ -49,16 +41,11 @@ class TangyAcasiWidget extends TangyBaseWidget {
   downcast(config) {
     return `
       <tangy-acasi 
-        name="${config.name}"
+        ${this.downcastCommonAttributes(config)}
         label="${config.label}"
         hint-text="${config.hintText}"
         type="text"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
         allowed-pattern="${config.allowedPattern}"
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
         ${config.images === "" ? "" : `images="${config.images.replace(/"/g, '&quot;')}"`}
         ${config.touchsrc === "" ? "" : `touchsrc="${config.touchsrc.replace(/"/g, '&quot;')}"`}
         ${config.introsrc === "" ? "" : `introsrc="${config.introsrc.replace(/"/g, '&quot;')}"`}
@@ -69,7 +56,6 @@ class TangyAcasiWidget extends TangyBaseWidget {
 
   renderPrint(config) {
     return `
-   
     <table>
       <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
@@ -101,17 +87,10 @@ class TangyAcasiWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add Acasi Input</h2>
+    return `
     <tangy-form id="tangy-acasii-widget">
       <tangy-form-item>
-        <tangy-input 
-          name="name" 
-          valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)" 
-          inner-label="Variable name"
-          value="${config.name}"
-          hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-          required>
-        </tangy-input>
+        ${this.renderEditCommonAttributes(config)}
         <tangy-input
           name="label"
           inner-label="Label"
@@ -129,33 +108,6 @@ class TangyAcasiWidget extends TangyBaseWidget {
           hint-text="Optional Javascript RegExp pattern to validate text (e.g. minimum length of 5 characters would be [a-zA-Z]{5,})
           value="${config.allowedPattern}">
         </tangy-input>
-        <tangy-input
-          name="tangy_if"
-          inner-label="Show if"
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input 
-          name="valid_if"
-          inner-label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-checkbox
-          name="required" 
-          ${config.required ? 'value="on"' : ''}>
-          Required
-        </tangy-checkbox>
-        <tangy-checkbox
-          name="disabled" 
-          ${config.disabled ? 'value="on"' : ''}>
-          Disabled
-        </tangy-checkbox>
-        <tangy-checkbox
-          name="hidden"
-          ${config.hidden ? 'value="on"' : ''}>
-          Hidden
-        </tangy-checkbox>
         <h2>Media Elements</h2>
         <p>Paths: Images should use the format: "./assets/images/image.png". Sounds should take the format "./assets/sounds/sound.mp3"</p>
         <h3>Page Loading Sound</h3>
@@ -193,35 +145,13 @@ class TangyAcasiWidget extends TangyBaseWidget {
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
-        .value,
+      ...this.onSubmitCommonAttributes(config, formEl),
       label: formEl.response.items[0].inputs.find(
         input => input.name === 'label'
       ).value,
       hintText: formEl.values.hintText,
-      required:
-        formEl.response.items[0].inputs.find(input => input.name === 'required')
-          .value === 'on'
-          ? true
-          : false,
-      hidden:
-        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
-          .value === 'on'
-          ? true
-          : false,
-      disabled:
-        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
-          .value === 'on'
-          ? true
-          : false,
       allowedPattern: formEl.response.items[0].inputs.find(
         input => input.name === 'allowed_pattern'
-      ).value,
-      validIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'valid_if'
-      ).value,
-      tangyIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'tangy_if'
       ).value,
       images: formEl.response.items[0].inputs.find(
         input => input.name === 'images'
@@ -237,6 +167,7 @@ class TangyAcasiWidget extends TangyBaseWidget {
       ).value
     };
   }
+
 }
 
 window.customElements.define('tangy-acasi-widget', TangyAcasiWidget);

--- a/widget/tangy-box-widget.js
+++ b/widget/tangy-box-widget.js
@@ -11,12 +11,7 @@ class TangyBoxWidget extends TangyBaseWidget {
 
   get defaultConfig() {
     return {
-      name: '',
-      required: false,
-      disabled: false,
-      hidden: false,
-      tangyIf: '',
-      validIf: '',
+      ...this.defaultConfigCommonAttributes(),
       htmlCode:  ''
     }
   }
@@ -24,26 +19,15 @@ class TangyBoxWidget extends TangyBaseWidget {
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyBox.props thus won't get picked up by TangyBox.getProps().
     return {...config,
-      ...element.getProps(),
-      htmlCode: element.innerHTML,
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-        : '',
-      validIf: element.hasAttribute('valid-if')
-        ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-        : ''
+      ...this.upcastCommonAttributes(config, element),
+      htmlCode: element.innerHTML
     }
   }
 
   downcast(config) {
     return `
       <tangy-box 
-        name="${config.name}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
+        ${this.downcastCommonAttributes(config)}
       >${config.htmlCode}</tangy-box>
     `
   }
@@ -55,32 +39,10 @@ class TangyBoxWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add HTML content</h2>
+    return `
     <tangy-form id="tangy-input">
       <tangy-form-item>
-        <tangy-input 
-          name="name" 
-          valid-if="input.value && input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-          hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-          inner-label="Enter the variable name you would like displayed on all data outputs (e.g. employee_id)."
-          value="${config.name}" 
-          required>
-        </tangy-input>
-        <tangy-input 
-          name="tangy_if" 
-          inner-label="Show if" 
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input
-          name="valid_if"
-          inner-label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
+        ${this.renderEditCommonAttributes(config)}
         <tangy-code mode="ace/mode/html" name="htmlCode" height="600" required>
           ${config.htmlCode}
         </tangy-code>
@@ -91,12 +53,7 @@ class TangyBoxWidget extends TangyBaseWidget {
 
   onSubmit(config, formEl) {
     return {
-      ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name').value,
-      hidden: formEl.response.items[0].inputs.find(input => input.name === 'hidden').value === 'on' ? true : false,
-      disabled: formEl.response.items[0].inputs.find(input => input.name === 'disabled').value === 'on' ? true : false,
-      tangyIf: formEl.response.items[0].inputs.find(input => input.name === 'tangy_if').value,
-      validIf: formEl.response.items[0].inputs.find(input => input.name === 'valid_if').value,
+      ...this.onSubmitCommonAttributes(config, formEl),
       htmlCode: formEl.response.items[0].inputs.find(input => input.name === 'htmlCode').value
     }
   }

--- a/widget/tangy-checkbox-widget.js
+++ b/widget/tangy-checkbox-widget.js
@@ -8,43 +8,20 @@ class TangyCheckboxWidget extends TangyBaseWidget {
     return 'tangy-checkbox'
   }
 
-  get defaultConfig() {
-    return {
-      name: '',
-      label: '',
-      type: 'text',
-      required: false,
-      disabled: false,
-      hidden: false,
-      allowedPattern: '',
-      tangyIf: '',
-      validIf: ''
-    }
-  }
-
   upcast(config, element) {
-    // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
-    return {...config, ...element.getProps(), ...{
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-        : '',
-      validIf: element.hasAttribute('valid-if')
-        ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-        : ''
-    }}
+    return { 
+      ...this.upcastCommonAttributes(config, element),
+      ...this.upcastLabelAttributes(config, element),
+      label: element.innerHTML
+    }
   }
 
   downcast(config) {
     return `
       <tangy-checkbox 
-        name="${config.name}"
-        label="${config.label}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
-      ></tangy-checkbox>
+        ${this.downcastCommonAttributes(config)}
+        ${this.downcastLabelAttributes(config)}
+      >${config.label}</tangy-checkbox>
     `
   }
   
@@ -52,57 +29,6 @@ class TangyCheckboxWidget extends TangyBaseWidget {
     const icon = this.shadowRoot.querySelector('#icon').innerHTML=`<span class="header-text"><mwc-icon>check_box</mwc-icon><span>`
     const name = this.shadowRoot.querySelector('#name').innerHTML=`<span class="header-text">${config.name}</span>`
     return `${icon} ${name} ${this.downcast(config)}`;
-  }
-
-  renderEdit(config) {
-    return `<h2>Add Checkbox</h2>
-    <tangy-form id="tangy-checkbox">
-      <tangy-form-item>
-        <tangy-input
-          name="name"
-          valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-          inner-label="Variable name"
-          value="${config.name}"
-          hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-          required>
-        </tangy-input>
-        <tangy-input 
-          name="label" 
-          hint-text="Enter the label of the checkbox."
-          inner-label="Label"
-          value="${config.label}">
-        </tangy-input>
-        <tangy-input
-          name="tangy_if"
-          inner-label="Show if"
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input
-          name="valid_if"
-          inner-label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
-      </tangy-form-item>
-    </tangy-form>
-    `
-  }
-
-  onSubmit(config, formEl) {
-    return {
-      ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name').value,
-      label: formEl.response.items[0].inputs.find(input => input.name === 'label').value,
-      required: formEl.response.items[0].inputs.find(input => input.name === 'required').value === 'on' ? true : false,
-      hidden: formEl.response.items[0].inputs.find(input => input.name === 'hidden').value === 'on' ? true : false,
-      disabled: formEl.response.items[0].inputs.find(input => input.name === 'disabled').value === 'on' ? true : false,
-      tangyIf: formEl.response.items[0].inputs.find(input => input.name === 'tangy_if').value,
-      validIf: formEl.response.items[0].inputs.find(input => input.name === 'valid_if').value
-    }
   }
 
 }

--- a/widget/tangy-checkboxes-widget.js
+++ b/widget/tangy-checkboxes-widget.js
@@ -20,7 +20,6 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
   }
 
   upcast(config, element) {
-    // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
     return {
       ...this.upcastCommonAttributes(config, element),
       ...this.upcastLabelAttributes(config, element),

--- a/widget/tangy-checkboxes-widget.js
+++ b/widget/tangy-checkboxes-widget.js
@@ -8,7 +8,7 @@ import { TangyBaseWidget } from '../tangy-base-widget.js';
 class TangyCheckboxesWidget extends TangyBaseWidget {
   
   get claimElement() {
-    return 'tangy-checkboxes';
+    return 'tangy-checkboxes'
   }
 
   get defaultConfig() {
@@ -16,7 +16,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
       ...this.defaultConfigCommonAttributes(),
       ...this.defaultConfigLabelAttributes(),
       options: []
-    };
+    }
   }
 
   upcast(config, element) {
@@ -27,9 +27,9 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
         return {
           value: option.getAttribute('value'),
           label: option.innerHTML
-        };
+        }
       })
-    };
+    }
   }
 
   downcast(config) {
@@ -42,7 +42,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
           <option value="${option.value}">${option.label}</option>
         `).join('')}
       </tangy-checkboxes>
-    `;
+    `
   }
 
   renderPrint(config) {
@@ -61,7 +61,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
       <tr><td><strong>Options:</strong></td><td><ul>${keyValuePairs}</ul></td></tr>
     </table>
     <hr/>
-    `;
+    `
   }
 
   renderInfo(config) {
@@ -96,7 +96,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
           </template>
         </tangy-form-item>
       </tangy-form>
-    `;
+    `
   }
 
   onSubmit(config, formEl) {
@@ -105,10 +105,10 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
       ...this.onSubmitLabelAttributes(config, formEl),
       options: formEl.values.options.map(item =>
         item.reduce((acc, input) => {
-          return { ...acc, [input.name]: input.value };
+          return { ...acc, [input.name]: input.value }
         }, {})
       )
-    };
+    }
   }
 
 }

--- a/widget/tangy-checkboxes-widget.js
+++ b/widget/tangy-checkboxes-widget.js
@@ -6,73 +6,52 @@ import 'tangy-form/input/tangy-input.js';
 import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyCheckboxesWidget extends TangyBaseWidget {
+  
   get claimElement() {
     return 'tangy-checkboxes';
   }
 
   get defaultConfig() {
     return {
-      name: '',
-      label: '',
-      hintText: '',
-      options: [],
-      required: false,
-      disabled: false,
-      hidden: false,
-      tangyIf: '',
-      validIf: ''
+      ...this.defaultConfigCommonAttributes(),
+      ...this.defaultConfigLabelAttributes(),
+      options: []
     };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
     return {
-      ...config,
-      ...element.getProps(),
+      ...this.upcastCommonAttributes(config, element),
+      ...this.upcastLabelAttributes(config, element),
       options: [...element.querySelectorAll('option')].map(option => {
         return {
           value: option.getAttribute('value'),
           label: option.innerHTML
         };
-      }),
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-        : '',
-      validIf: element.hasAttribute('valid-if')
-        ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-        : ''
+      })
     };
   }
 
   downcast(config) {
     return `
       <tangy-checkboxes
-        name="${config.name}"
-        label="${config.label}"
-        hint-text="${config.hintText}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
+        ${this.downcastCommonAttributes(config)}
+        ${this.downcastLabelAttributes(config)}
       >
-       ${config.options
-         .map(
-           option => `
-        <option value="${option.value}">${option.label}</option>
-      `
-         )
-         .join('')}
+        ${config.options.map(option => `
+          <option value="${option.value}">${option.label}</option>
+        `).join('')}
       </tangy-checkboxes>
     `;
   }
+
   renderPrint(config) {
     let keyValuePairs = '';
     config.options.map(option => {
       keyValuePairs += `<li>${option.value}: ${option.label}</li>`;
     });
     return `
-   
     <table>
       <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
@@ -85,6 +64,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
     <hr/>
     `;
   }
+
   renderInfo(config) {
     const icon = this.shadowRoot.querySelector('#icon').innerHTML=`<span class="header-text"><mwc-icon>check_box_outline_blank</mwc-icon><span>`
     const name = this.shadowRoot.querySelector('#name').innerHTML=`<span class="header-text">${config.name}</span>`
@@ -92,118 +72,38 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add Group of Checkboxes</h2>
-    <tangy-form id="tangy-checkboxes">
-      <tangy-form-item id="tangy-checkboxes">
-        <template type="tangy-form-item">
-          <tangy-input 
-            valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-            name="name"
-            inner-label="Variable name"
-            hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-            value="${config.name}"
-            required>
-          </tangy-input>
-          <tangy-input
-            name="label"
-            inner-label="Label"
-            hint-text="Enter the Question or Statement Text"
-            value="${
-              config.label
-            }">
-          </tangy-input>
-          <tangy-input
-            name="tangy_if"
-            inner-label="Show if"
-            hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-            value="${config.tangyIf.replace(/"/g, '&quot;')}">
-          </tangy-input>
-          <tangy-input
-            name="valid_if"
-            inner-label="Valid if"
-            hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-            value="${config.validIf.replace(/"/g, '&quot;')}">
-          </tangy-input>
-          <tangy-input name="hintText" inner-label="Hint Text" value="${
-            config.hintText
-          }"></tangy-input>
-          <tangy-checkbox name="required" ${
-            config.required ? 'value="on"' : ''
-          }>Required</tangy-checkbox>
-          <tangy-checkbox name="disabled" ${
-            config.disabled ? 'value="on"' : ''
-          }>Disabled</tangy-checkbox>
-          <tangy-checkbox name="hidden" ${
-            config.hidden ? 'value="on"' : ''
-          }>Hidden</tangy-checkbox>
-          <tangy-list name="options">
-            <template type="tangy-list/new-item">
-              <tangy-input name="value" allowed-pattern="[a-zA-Z0-9\-_]" inner-label="Value" hint-text="Enter the variable value if checkbox is chosen" type="text"></tangy-input>
-              <tangy-input name="label" inner-label="Label" hint-text="Enter the display label of the checkbox" type="text"></tangy-input>
-            </template>
-            ${
-              config.options.length > 0
-                ? `
-            <template type="tangy-list/initial-items">
-              ${config.options
-                .map(
-                  option => `
-                <tangy-list-item>
-                  <tangy-input name="value" allowed-pattern="[a-zA-Z0-9\-_]" inner-label="Value" hint-text="Enter the variable value if checkbox is chosen" type="text" value="${
-                    option.value
-                  }"></tangy-input>
-                  <tangy-input name="label" hint-text="Enter the display label of the checkbox" inner-label="Label" type="text" value="${
-                    option.label
-                  }"></tangy-input>
-                </tangy-list-item>  
-              `
-                )
-                .join('')}
-            </template>
-            `
-                : ''
-            }
-          </tangy-list>
-        </template>
-      </tangy-form-item>
-    </tangy-form>
+    return `
+      <tangy-form id="tangy-checkboxes">
+        <tangy-form-item id="tangy-checkboxes">
+          <template>
+            ${this.renderEditCommonAttributes(config)}
+            ${this.renderEditLabelAttributes(config)}
+            <tangy-list name="options">
+              <template type="tangy-list/new-item">
+                <tangy-input name="value" allowed-pattern="[a-zA-Z0-9\-_]" inner-label="Value" hint-text="Enter the variable value if checkbox is chosen" type="text"></tangy-input>
+                <tangy-input name="label" inner-label="Label" hint-text="Enter the display label of the checkbox" type="text"></tangy-input>
+              </template>
+              ${config.options.length > 0 ? `
+                <template type="tangy-list/initial-items">
+                  ${config.options.map(option => `
+                    <tangy-list-item>
+                      <tangy-input name="value" allowed-pattern="[a-zA-Z0-9\-_]" inner-label="Value" hint-text="Enter the variable value if checkbox is chosen" type="text" value="${option.value}"></tangy-input>
+                      <tangy-input name="label" hint-text="Enter the display label of the checkbox" inner-label="Label" type="text" value="${option.label}"></tangy-input>
+                    </tangy-list-item>  
+                  `).join('')}
+                </template>
+              `: ''}
+            </tangy-list>
+          </template>
+        </tangy-form-item>
+      </tangy-form>
     `;
-  }
-
-  editResponse(config) {
-    return {
-      form: {
-        complete: false
-      },
-      items: [
-        {
-          id: 'tangy-checkboxes',
-          inputs: [
-            {
-              name: 'name',
-              value: config.name
-            },
-            {
-              name: 'label',
-              value: config.label
-            }
-          ]
-        }
-      ]
-    };
   }
 
   onSubmit(config, formEl) {
     return {
-      ...config,
-      name: formEl.values.name,
-      label: formEl.values.label,
-      required: formEl.values.required === 'on' ? true : false,
-      hidden: formEl.values.hidden === 'on' ? true : false,
-      tangyIf: formEl.response.items[0].inputs.find(input => input.name === 'tangy_if').value,
-      validIf: formEl.response.items[0].inputs.find(input => input.name === 'valid_if').value,
-      disabled: formEl.values.disabled === 'on' ? true : false,
-      hintText: formEl.values.hintText,
+      ...this.onSubmitCommonAttributes(config, formEl),
+      ...this.onSubmitLabelAttributes(config, formEl),
       options: formEl.values.options.map(item =>
         item.reduce((acc, input) => {
           return { ...acc, [input.name]: input.value };
@@ -211,6 +111,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
       )
     };
   }
+
 }
 
 window.customElements.define('tangy-checkboxes-widget', TangyCheckboxesWidget);

--- a/widget/tangy-consent-widget.js
+++ b/widget/tangy-consent-widget.js
@@ -11,50 +11,33 @@ class TangyConsentWidget extends TangyBaseWidget {
 
   get defaultConfig() {
     return {
-      name: '',
-      prompt: '',
-      required: false,
-      disabled: false,
-      hidden: false,
-      tangyIf: '',
-      validIf: ''
+      ...this.defaultConfigCommonAttributes(),
+      metaDataTemplate: '',
+      prompt: ''
     };
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyQr.props thus won't get picked up by TangyQr.getProps().
     return {
-      ...config,
-      ...element.getProps(),
-      ...{
-        tangyIf: element.hasAttribute('tangy-if')
-          ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-          : '',
-        validIf: element.hasAttribute('valid-if')
-          ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-          : ''
-      }
+      ...this.upcastCommonAttributes(config, element),
+      ...element.getProps()
     };
   }
 
   downcast(config) {
     return `
       <tangy-consent 
-        name="${config.name}"
+        ${this.downcastCommonAttributes(config)}
         prompt="${config.prompt}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
       >
         ${config.metaDataTemplate}
       </tangy-consent>
     `;
   }
+
   renderPrint(config) {
     return `
-
     <table>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
       <tr><td><strong>Prompt:</strong></td><td>${config.prompt}</td></tr>
@@ -65,6 +48,7 @@ class TangyConsentWidget extends TangyBaseWidget {
     <hr/>
     `;
   }
+
   renderInfo(config) {
     return `<div class="element-header"><div><mwc-icon>thumbs_up_down</mwc-icon></div><div id="element-name">${
       config.name
@@ -73,80 +57,28 @@ class TangyConsentWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add Consent</h2>
-    <tangy-form id="tangy-consent">
-      <tangy-form-item>
-        <tangy-input
-          name="name"
-          valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-          inner-label="Variable name" 
-          value="${
-            config.name
-          }"
-          required>
-        </tangy-input>
-        <tangy-input
-          name="prompt"
-          inner-label="Prompt" 
-          value="${
-            config.prompt
-          }"
-          required>
-        </tangy-input>
-        <tangy-input 
-          name="tangy_if"
-          inner-label="Show if"
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input
-          name="valid_if"
-          inner-label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-checkbox name="required" ${
-          config.required ? 'value="on"' : ''
-        }>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${
-          config.disabled ? 'value="on"' : ''
-        }>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${
-          config.hidden ? 'value="on"' : ''
-        }>Hidden</tangy-checkbox>
-      </tangy-form-item>
-    </tangy-form>
+    return `
+      <tangy-form id="tangy-consent">
+        <tangy-form-item>
+          ${this.renderEditCommonAttributes(config)}
+          <tangy-input
+            name="prompt"
+            inner-label="Prompt" 
+            value="${
+              config.prompt
+            }"
+            required>
+          </tangy-input>
+        
+        </tangy-form-item>
+      </tangy-form>
     `;
   }
 
   onSubmit(config, formEl) {
     return {
-      ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
-        .value,
-      prompt: formEl.response.items[0].inputs.find(input => input.name === 'prompt')
-        .value,
-      required:
-        formEl.response.items[0].inputs.find(input => input.name === 'required')
-          .value === 'on'
-          ? true
-          : false,
-      hidden:
-        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
-          .value === 'on'
-          ? true
-          : false,
-      disabled:
-        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
-          .value === 'on'
-          ? true
-          : false,
-      tangyIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'tangy_if'
-      ).value,
-      validIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'valid_if'
-      ).value
+      ...this.onSubmitCommonAttributes(config, formEl),
+      prompt: formEl.response.items[0].inputs.find(input => input.name === 'prompt').value
     };
   }
 }

--- a/widget/tangy-date-widget.js
+++ b/widget/tangy-date-widget.js
@@ -4,58 +4,39 @@ import 'tangy-form/input/tangy-select.js';
 import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyDateWidget extends TangyBaseWidget {
+
   get claimElement() {
     return 'tangy-input[type=date]';
   }
 
   get defaultConfig() {
     return {
-      name: '',
-      label: '',
-      hintText: '',
       type: 'date',
-      required: false,
-      disabled: false,
-      hidden: false,
-      tangyIf: '',
-      validIf: ''
+      ...this.defaultConfigCommonAttributes(),
+      ...this.defaultConfigLabelAttributes()
     };
   }
 
   upcast(config, element) {
-    // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyDate.props thus won't get picked up by TangyDate.getProps().
     return {
-      ...config,
-      ...element.getProps(),
-      ...{
-        tangyIf: element.hasAttribute('tangy-if')
-          ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-          : '',
-        validIf: element.hasAttribute('valid-if')
-          ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-          : ''
-      }
+      ...this.upcastCommonAttributes(config, element),
+      ...this.upcastLabelAttributes(config, element),
+      ...element.getProps()
     };
   }
 
   downcast(config) {
     return `
       <tangy-input 
-        name="${config.name}"
-        label="${config.label}"
-        hint-text="${config.hintText}"
+        ${this.downcastCommonAttributes(config)}
+        ${this.downcastLabelAttributes(config)}
         type="date"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
       ></tangy-input>
     `;
   }
+
   renderPrint(config) {
     return `
-      
       <table>
         <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
         <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
@@ -77,6 +58,7 @@ class TangyDateWidget extends TangyBaseWidget {
       <hr/>
     `;
   }
+
   renderInfo(config) {
     const icon = this.shadowRoot.querySelector('#icon').innerHTML=`<span class="header-text"><mwc-icon>date_range</mwc-icon><span>`
     const name = this.shadowRoot.querySelector('#name').innerHTML=`<span class="header-text">${config.name}</span>`
@@ -84,93 +66,23 @@ class TangyDateWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add a Date Input</h2>
-    <tangy-form id="tangy-date-widget">
-      <tangy-form-item>
-        <tangy-input
-          name="name"
-          valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-          inner-label="Variable name" 
-          value="${
-            config.name
-          }"
-          hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-          required>
-        </tangy-input>
-        <tangy-input
-          name="label"
-          inner-label="Label"
-          hint-text="Enter the Question or Statement Text"
-          value="${
-            config.label
-          }">
-        </tangy-input>
-        <tangy-input 
-          name="hintText"
-          inner-label="Hint Text"
-          value="${
-            config.hintText
-          }">
-        </tangy-input>
-        <tangy-input
-          name="tangy_if"
-          inner-label="Show if"
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input
-          name="valid_if"
-          label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-checkbox name="required" ${
-          config.required ? 'value="on"' : ''
-        }>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${
-          config.disabled ? 'value="on"' : ''
-        }>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${
-          config.hidden ? 'value="on"' : ''
-        }>Hidden</tangy-checkbox>
-      </tangy-form-item>
-    </tangy-form>
+    return `
+      <tangy-form id="tangy-date-widget">
+        <tangy-form-item>
+          ${this.renderEditCommonAttributes(config)}
+          ${this.renderEditLabelAttributes(config)}
+        </tangy-form-item>
+      </tangy-form>
     `;
   }
 
   onSubmit(config, formEl) {
     return {
-      ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
-        .value,
-      label: formEl.response.items[0].inputs.find(
-        input => input.name === 'label'
-      ).value,
-      hintText: formEl.values.hintText,
-      required:
-        formEl.response.items[0].inputs.find(input => input.name === 'required')
-          .value === 'on'
-          ? true
-          : false,
-      hidden:
-        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
-          .value === 'on'
-          ? true
-          : false,
-      disabled:
-        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
-          .value === 'on'
-          ? true
-          : false,
-      tangyIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'tangy_if'
-      ).value,
-      validIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'valid_if'
-      ).value
-
+      ...this.onSubmitCommonAttributes(config, formEl),
+      ...this.onSubmitLabelAttributes(config, formEl)
     };
   }
+
 }
 
 window.customElements.define('tangy-date-widget', TangyDateWidget);

--- a/widget/tangy-eftouch-widget.js
+++ b/widget/tangy-eftouch-widget.js
@@ -13,7 +13,7 @@ class TangyEftouchWidget extends TangyBaseWidget {
 
   get defaultConfig() {
     return {
-      name: '',
+      ...this.defaultConfigCommonAttributes(),
       label: '',
       optionsMarkup: '',
       openSound: '',
@@ -24,11 +24,7 @@ class TangyEftouchWidget extends TangyBaseWidget {
       warningMessage: '',
       warningTime: '',
       timeLimit: '',
-      tangyIf: '',
-      validIf: '',
       autoProgress: false,
-      required: false,
-      hidden: false,
       multiSelect: false,
       requiredCorrect: false,
       ifIncorrectThenHighlightCorrect: false,
@@ -40,18 +36,13 @@ class TangyEftouchWidget extends TangyBaseWidget {
     return {
       ...config,
       ...element.getProps(),
+      ...this.upcastCommonAttributes(config, element),
       ...{
         multiSelect: element.hasAttribute('multi-select'),
         requiredCorrect: element.hasAttribute('required-correct'),
         ifIncorrectThenHighlightCorrect: element.hasAttribute('if-incorrect-then-highlight-correct'),
         noCorrections: element.hasAttribute('no-corrections'),
         openSound: element.hasAttribute('open-sound') ? element.getAttribute('open-sound') : '',
-        tangyIf: element.hasAttribute('tangy-if')
-          ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-          : '',
-        validIf: element.hasAttribute('valid-if')
-          ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-          : '',
         optionsMarkup: element.innerHTML
       }
     };
@@ -60,7 +51,7 @@ class TangyEftouchWidget extends TangyBaseWidget {
   downcast(config) {
     return `
       <tangy-eftouch
-        name="${config.name}"
+        ${this.downcastCommonAttributes(config)}
         label="${config.label}"
         open-sound="${config.openSound}"
         input-sound="${config.inputSound}"
@@ -70,11 +61,7 @@ class TangyEftouchWidget extends TangyBaseWidget {
         warning-message="${config.warningMessage}"
         warning-time="${config.warningTime}"
         time-limit="${config.timeLimit}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
         ${config.autoProgress ? 'auto-progress' : ''}
-        ${config.required ? 'required' : ''}
-        ${config.hidden ? 'hidden' : ''}
         ${config.multiSelect ? 'multi-select' : ''}
         ${config.requiredCorrect ? 'required-correct' : ''}
         ${config.ifIncorrectThenHighlightCorrect ? 'if-incorrect-then-highlight-correct' : ''}
@@ -112,34 +99,13 @@ class TangyEftouchWidget extends TangyBaseWidget {
           margin: 0px 0px 0px 10px;
         }
         </style>
-          <tangy-input
-            name="name"
-            valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-            inner-label="Variable name"
-            hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-            value="${
-            config.name
-            }"
-            required>
-          </tangy-input>
+          ${this.renderEditCommonAttributes(config)}
           <tangy-input
             name="label"
             inner-label="Label"
             value="${
               config.label
             }">
-          </tangy-input>
-          <tangy-input
-            name="tangy_if"
-            inner-label="Show if"
-            hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-            value="${config.tangyIf.replace(/"/g, '&quot;')}">
-          </tangy-input>
-          <tangy-input
-            name="valid_if"
-            inner-label="Valid if"
-            hint-text="Enter any conditional validation logic."
-            value="${config.validIf.replace(/"/g, '&quot;')}">
           </tangy-input>
           <label for="open-sound">Open sound</label>
           <file-list-select name="open-sound" endpoint="${this.getAttribute('files-endpoint')}" value="${
@@ -171,12 +137,6 @@ class TangyEftouchWidget extends TangyBaseWidget {
           <tangy-checkbox name="auto-progress" ${
             config.autoProgress ? 'value="on"' : ''
           }>auto-progress</tangy-checkbox>
-          <tangy-checkbox name="required" ${
-            config.required ? 'value="on"' : ''
-          }>Required</tangy-checkbox>
-          <tangy-checkbox name="hidden" ${
-            config.hidden ? 'value="on"' : ''
-          }>Hidden</tangy-checkbox>
           <tangy-checkbox name="multi-select" ${
             config.multiSelect ? 'value="on"' : ''
           }>multi-select</tangy-checkbox>
@@ -200,7 +160,6 @@ class TangyEftouchWidget extends TangyBaseWidget {
 
   renderPrint(config) {
     return `
-   
     <table>
     <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
     <tr><td><strong>Variable Label:</strong></td><td>${config.label}</td></tr>
@@ -233,10 +192,11 @@ class TangyEftouchWidget extends TangyBaseWidget {
     <hr/>
     `;
   }
+
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.values.name,
+      ...this.onSubmitCommonAttributes(config, formEl),
       label: formEl.values.label,
       inputSound: formEl.querySelector('tangy-form-item').querySelector('[name=input-sound]').value,
       transitionDelay: formEl.values['transition-delay'],
@@ -246,20 +206,12 @@ class TangyEftouchWidget extends TangyBaseWidget {
       warningTime: formEl.values['warning-time'],
       timeLimit: formEl.values['time-limit'],
       autoProgress: formEl.values['auto-progress'] === 'on' ? true : false,
-      required: formEl.values.required === 'on' ? true : false,
-      hidden: formEl.values.hidden === 'on' ? true : false,
       openSound: formEl.querySelector('tangy-form-item').querySelector('[name=open-sound]').value,
       multiSelect: formEl.values['multi-select'] === 'on' ? true : false,
       requiredCorrect: formEl.values['required-correct'] === 'on' ? true : false,
       ifIncorrectThenHighlightCorrect: formEl.values['if-incorrect-then-highlight-correct'] === 'on' ? true : false,
       noCorrections: formEl.values['no-corrections'] === 'on' ? true : false,
-      optionsMarkup: formEl.values['options-markup'],
-      tangyIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'tangy_if'
-      ).value,
-      validIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'valid_if'
-      ).value
+      optionsMarkup: formEl.values['options-markup']
     };
   }
 }

--- a/widget/tangy-email-widget.js
+++ b/widget/tangy-email-widget.js
@@ -4,58 +4,40 @@ import 'tangy-form/input/tangy-select.js';
 import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyEmailWidget extends TangyBaseWidget {
+
   get claimElement() {
     return 'tangy-input[type=email]';
   }
 
   get defaultConfig() {
     return {
-      name: '',
-      label: '',
-      hintText: '',
-      type: 'email',
-      required: false,
-      disabled: false,
-      hidden: false,
-      tangyIf: '',
-      validIf: ''
-    };
+      ...this.defaultConfigCommonAttributes(),
+      ...this.defaultConfigLabelAttributes(),
+      innerLabel: ''
+    }
   }
 
   upcast(config, element) {
-    // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyEmail.props thus won't get picked up by TangyEmail.getProps().
     return {
-      ...config,
-      ...element.getProps(),
-      ...{
-        tangyIf: element.hasAttribute('tangy-if')
-          ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-          : '',
-        validIf: element.hasAttribute('valid-if')
-          ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-          : ''
-      }
-    };
+      ...this.upcastCommonAttributes(config, element),
+      ...this.upcastLabelAttributes(config, element),
+      ...element.getProps()
+    }
   }
 
   downcast(config) {
     return `
       <tangy-input 
-        name="${config.name}"
-        label="${config.label}"
-        hint-text="${config.hintText}"
+        ${this.downcastCommonAttributes(config)}
+        ${this.downcastLabelAttributes(config)}
+        inner-label="${config.innerLabel}"
         type="email"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
       ></tangy-input>
-    `;
+    `
   }
+
   renderPrint(config) {
     return `
-   
     <table>
       <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
@@ -75,6 +57,7 @@ class TangyEmailWidget extends TangyBaseWidget {
     <hr/>
     `;
   }
+
   renderInfo(config) {
     const icon = this.shadowRoot.querySelector('#icon').innerHTML=`<span class="header-text"><mwc-icon>emailr</mwc-icon><span>`
     const name = this.shadowRoot.querySelector('#name').innerHTML=`<span class="header-text">${config.name}</span>`
@@ -82,88 +65,33 @@ class TangyEmailWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add Email Input</h2>
-    <tangy-form id="tangy-email-widget">
-      <tangy-form-item>
-        <tangy-input
-          name="name"
-          valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-          inner-label="Variable name" 
-          hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-          value="${
-            config.name
-          }" 
-          required>
-        </tangy-input>
-        <tangy-input
-          name="label"
-          inner-label="Label"
-          hint-text="Enter the Question or Statement Text"
-          value="${
-            config.label
-          }">
-        </tangy-input>
-        <tangy-input name="hintText" inner-label="Hint Text" value="${
-          config.hintText
-        }"></tangy-input>
-        <tangy-input
-          name="tangy_if"
-          inner-label="Show if"
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input
-          name="valid_if"
-          inner-label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-checkbox name="required" ${
-          config.required ? 'value="on"' : ''
-        }>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${
-          config.disabled ? 'value="on"' : ''
-        }>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${
-          config.hidden ? 'value="on"' : ''
-        }>Hidden</tangy-checkbox>
-      </tangy-form-item>
-    </tangy-form>
+    return `
+      <tangy-form id="tangy-email-widget">
+        <tangy-form-item>
+          ${this.renderEditCommonAttributes(config)}
+          ${this.renderEditLabelAttributes(config)}
+          <tangy-input
+            name="inner_label"
+            inner-label="Inner Label"
+            value="${
+              config.innerLabel
+            }">
+          </tangy-input>
+        </tangy-form-item>
+      </tangy-form>
     `;
   }
 
   onSubmit(config, formEl) {
     return {
-      ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
-        .value,
-      label: formEl.response.items[0].inputs.find(
-        input => input.name === 'label'
-      ).value,
-      hintText: formEl.values.hintText,
-      required:
-        formEl.response.items[0].inputs.find(input => input.name === 'required')
-          .value === 'on'
-          ? true
-          : false,
-      hidden:
-        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
-          .value === 'on'
-          ? true
-          : false,
-      disabled:
-        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
-          .value === 'on'
-          ? true
-          : false,
-      tangyIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'tangy_if'
-      ).value,
-      validIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'valid_if'
+      ...this.onSubmitCommonAttributes(config, formEl),
+      ...this.onSubmitLabelAttributes(config, formEl),
+      innerLabel: formEl.response.items[0].inputs.find(
+        input => input.name === 'inner_label'
       ).value
-    };
+    }
   }
+
 }
 
 window.customElements.define('tangy-email-widget', TangyEmailWidget);

--- a/widget/tangy-gps-widget.js
+++ b/widget/tangy-gps-widget.js
@@ -4,54 +4,35 @@ import 'tangy-form/input/tangy-select.js';
 import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyGpsWidget extends TangyBaseWidget {
+
   get claimElement() {
     return 'tangy-gps';
   }
 
   get defaultConfig() {
     return {
-      name: '',
-      hintText: '',
-      required: false,
-      disabled: false,
-      hidden: false,
-      tangyIf: '',
-      validIf: ''
+      ...this.defaultConfigCommonAttributes(),
+      hintText: ''
     };
   }
 
   upcast(config, element) {
-    // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyGPS.props thus won't get picked up by TangyGPS.getProps().
     return {
-      ...config,
-      ...element.getProps(),
-      ...{
-        tangyIf: element.hasAttribute('tangy-if')
-          ? element.getattribute('tangy-if').replace(/&quot;/g, '"')
-          : '',
-        validIf: element.hasAttribute('valid-if')
-          ? element.getattribute('valid-if').replace(/&quot;/g, '"')
-          : ''
-      }
+      ...this.upcastCommonAttributes(config, element),
+      hintText: element.hasAttribute('hint-text') ? element.getAttribute('hint-text') : ''
     };
   }
 
   downcast(config) {
     return `
       <tangy-gps 
-        name="${config.name}"
+        ${this.downcastCommonAttributes(config)}
         hint-text="${config.hintText}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
       ></tangy-gps>
     `;
   }
   renderPrint(config) {
     return `
-   
     <table>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
       <tr><td><strong>Hint:</strong></td><td>${config.hintText}</td></tr>
@@ -83,6 +64,7 @@ class TangyGpsWidget extends TangyBaseWidget {
     <hr/>
     `;
   }
+
   renderInfo(config) {
     const icon = this.shadowRoot.querySelector('#icon').innerHTML=`<span class="header-text"><mwc-icon>add_location</mwc-icon><span>`
     const name = this.shadowRoot.querySelector('#name').innerHTML=`<span class="header-text">${config.name}</span>`
@@ -90,79 +72,26 @@ class TangyGpsWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add GPS Element</h2>
-    <tangy-form id="tangy-gps">
-      <tangy-form-item>
-        <tangy-input
-          name="name"
-          valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-          inner-label="Variable name"
-          hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-          value="${
-            config.name
-          }"
-          required>
-        </tangy-input>
-        <tangy-input name="hintText"
-          inner-label="Hint Text"
-          value="${
-            config.hintText
-          }">
-        </tangy-input>
-        <tangy-input
-          name="tangy_if"
-          inner-label="Show if"
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input
-          name="valid_if"
-          inner-label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-checkbox name="required" ${
-          config.required ? 'value="on"' : ''
-        }>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${
-          config.disabled ? 'value="on"' : ''
-        }>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${
-          config.hidden ? 'value="on"' : ''
-        }>Hidden</tangy-checkbox>
-      </tangy-form-item>
-    </tangy-form>
-    `;
+    return `
+      <tangy-form id="tangy-gps">
+        <tangy-form-item>
+          ${this.renderEditCommonAttributes(config)}
+          <tangy-input name="hintText"
+            inner-label="Hint Text"
+            value="${
+              config.hintText
+            }">
+          </tangy-input>
+        </tangy-form-item>
+      </tangy-form>
+    `
   }
 
   onSubmit(config, formEl) {
     return {
-      ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
-        .value,
-      required:
-        formEl.response.items[0].inputs.find(input => input.name === 'required')
-          .value === 'on'
-          ? true
-          : false,
-      hintText: formEl.values.hintText,
-      hidden:
-        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
-          .value === 'on'
-          ? true
-          : false,
-      disabled:
-        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
-          .value === 'on'
-          ? true
-          : false,
-      tangyIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'tangy_if'
-      ).value,
-      validIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'valid_if'
-      ).value
-    };
+      ...this.onSubmitCommonAttributes(config, formEl),
+      hintText: formEl.values.hintText
+    }
   }
 }
 

--- a/widget/tangy-location-widget.js
+++ b/widget/tangy-location-widget.js
@@ -11,13 +11,8 @@ class TangyLocationWidget extends TangyBaseWidget {
 
   get defaultConfig() {
     return {
-      name: '',
+      ...this.defaultConfigCommonAttributes(),
       hintText: '',
-      required: false,
-      disabled: false,
-      hidden: false,
-      tangyIf: '',
-      validIf: '',
       showMetaData: false,
       metaDataTemplate: '',
       filterByGlobal: false,
@@ -26,32 +21,19 @@ class TangyLocationWidget extends TangyBaseWidget {
   }
 
   upcast(config, element) {
-    // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyLocation.props thus won't get picked up by TangyLocation.getProps().
     return {
       ...config,
       ...element.getProps(),
-      ...{
-        tangyIf: element.hasAttribute('tangy-if')
-          ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-          : '',
-        validIf: element.hasAttribute('valid-if')
-          ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-          : '',
-        metaDataTemplate: element.innerHTML
-      }
-    };
+      ...this.upcastCommonAttributes(config, element),
+      metaDataTemplate: element.innerHTML
+    }
   }
 
   downcast(config) {
     return `
       <tangy-location 
-        name="${config.name}"
+        ${this.downcastCommonAttributes(config)}
         hint-text="${config.hintText}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
         ${config.filterByGlobal ? 'filter-by-global' : ''}
         show-levels="${config.showLevels}"
         ${config.showMetaData ? 'show-meta-data' : ''}
@@ -60,9 +42,9 @@ class TangyLocationWidget extends TangyBaseWidget {
       </tangy-location>
     `;
   }
+
   renderPrint(config) {
     return `
-
     <table>
       <tr><td><strong>Location Levels:</strong></td><td>${
         config.showLevels
@@ -76,6 +58,7 @@ class TangyLocationWidget extends TangyBaseWidget {
     <hr/>
     `;
   }
+
   renderInfo(config) {
     const icon = this.shadowRoot.querySelector('#icon').innerHTML=`<span class="header-text"><mwc-icon>location_city</mwc-icon><span>`
     const name = this.shadowRoot.querySelector('#name').innerHTML=`<span class="header-text">${config.name}</span>`
@@ -83,87 +66,35 @@ class TangyLocationWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add Location Element</h2>
-    <tangy-form id="tangy-location">
-      <tangy-form-item>
-        <tangy-input
-          name="name"
-          valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-          inner-label="Variable name" 
-          hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-          value="${
-            config.name
-          }"
-          required>
-        </tangy-input>
-        <tangy-input name="hintText" inner-label="Hint Text" value="${
-          config.hintText
-        }"></tangy-input>
-        <tangy-checkbox name="filterByGlobal" ${
-          config.filterByGlobal ? 'value="on"' : ''
-        }>Filter by locations in the user profile?</tangy-checkbox>
-        <tangy-input name="showLevels" inner-label="Show levels" hint-text="e.g. county,subcounty" value="${
-          config.showLevels
-        }"></tangy-input>
-        <tangy-input 
-          name="tangy_if"
-          inner-label="Show if"
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input
-          name="valid_if"
-          inner-label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-checkbox name="required" ${
-          config.required ? 'value="on"' : ''
-        }>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${
-          config.disabled ? 'value="on"' : ''
-        }>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${
-          config.hidden ? 'value="on"' : ''
-        }>Hidden</tangy-checkbox>
-        <tangy-checkbox name="show-meta-data" ${
-          config.showMetaData ? 'value="on"' : ''
-        }>show meta-data</tangy-checkbox>
-        <tangy-input name="meta-data-template" label="Meta-data template" value="${
-          config.metaDataTemplate
-        }"></tangy-input>
-      </tangy-form-item>
-    </tangy-form>
+    return `
+      <tangy-form id="tangy-location">
+        <tangy-form-item>
+          ${this.renderEditCommonAttributes(config)}
+          <tangy-input name="hintText" inner-label="Hint Text" value="${
+            config.hintText
+          }"></tangy-input>
+          <tangy-checkbox name="filterByGlobal" ${
+            config.filterByGlobal ? 'value="on"' : ''
+          }>Filter by locations in the user profile?</tangy-checkbox>
+          <tangy-input name="showLevels" inner-label="Show levels" hint-text="e.g. county,subcounty" value="${
+            config.showLevels
+          }"></tangy-input>
+          <tangy-checkbox name="show-meta-data" ${
+            config.showMetaData ? 'value="on"' : ''
+          }>show meta-data</tangy-checkbox>
+          <tangy-input name="meta-data-template" label="Meta-data template" value="${
+            config.metaDataTemplate
+          }"></tangy-input>
+        </tangy-form-item>
+      </tangy-form>
     `;
   }
 
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
-        .value,
-      required:
-        formEl.response.items[0].inputs.find(input => input.name === 'required')
-          .value === 'on'
-          ? true
-          : false,
+      ...this.onSubmitCommonAttributes(config, formEl),
       hintText: formEl.values.hintText,
-      hidden:
-        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
-          .value === 'on'
-          ? true
-          : false,
-      disabled:
-        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
-          .value === 'on'
-          ? true
-          : false,
-      tangyIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'tangy_if'
-      ).value,
-      validIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'valid_if'
-      ).value,
       filterByGlobal: formEl.response.items[0].inputs.find(
         input => input.name === 'filterByGlobal'
       ).value === 'on'

--- a/widget/tangy-number-widget.js
+++ b/widget/tangy-number-widget.js
@@ -10,52 +10,33 @@ class TangyNumberWidget extends TangyBaseWidget {
 
   get defaultConfig() {
     return {
-      name: '',
-      label: '',
-      hintText: '',
-      type: 'text',
-      required: false,
-      disabled: false,
-      hidden: false,
+      ...this.defaultConfigCommonAttributes(),
+      ...this.defaultConfigLabelAttributes(),
       allowedPattern: '',
       min: undefined,
       max: undefined,
-      tangyIf: '',
-      validIf: ''
+      innerLabel: ''
     };
   }
 
   upcast(config, element) {
-    // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
     return {
-      ...config,
-      ...element.getProps(),
-      ...{
-        tangyIf: element.hasAttribute('tangy-if')
-          ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-          : '',
-        validIf: element.hasAttribute('valid-if')
-          ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-          : ''
-      }
-    };
+      ...this.upcastCommonAttributes(config, element),
+      ...this.upcastLabelAttributes(config, element),
+      ...element.getProps()
+    }
   }
 
   downcast(config) {
     return `
       <tangy-input 
-        name="${config.name}"
-        label="${config.label}"
-        hint-text="${config.hintText}"
+        ${this.downcastCommonAttributes(config)}
+        ${this.downcastLabelAttributes(config)}
         type="number"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
+        inner-label="${config.innerLabel}"
         allowed-pattern="${config.allowedPattern}"
         ${config.min ? `min="${config.min}"` : ``}
         ${config.max ? `max="${config.max}"` : ``}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
       ></tangy-input>
     `;
   }
@@ -65,9 +46,9 @@ class TangyNumberWidget extends TangyBaseWidget {
     const name = this.shadowRoot.querySelector('#name').innerHTML=`<span class="header-text">${config.name}</span>`
     return `${icon} ${name} ${this.downcast(config)}`;
   }
+
   renderPrint(config) {
     return `
-      
       <table>
       <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
@@ -89,45 +70,18 @@ class TangyNumberWidget extends TangyBaseWidget {
       <hr/>
     `;
   }
+
   renderEdit(config) {
-    return `<h2>Add Number Input</h2>
+    return `
     <tangy-form id="tangy-number-widget">
       <tangy-form-item>
+        ${this.renderEditCommonAttributes(config)}
+        ${this.renderEditLabelAttributes(config)}
         <tangy-input
-          name="name" 
-          valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-          inner-label="Variable name"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
+          name="inner_label"
+          inner-label="Inner Label"
           value="${
-            config.name
-          }"
-          required>
-        </tangy-input>
-        <tangy-input 
-          name="label"
-          inner-label="Label"
-          hint-text="Enter the Question or Statement Text"
-          value="${
-            config.label
-          }">
-        </tangy-input>
-        <tangy-input
-          name="tangy_if"
-          label="Show if"
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input
-          name="valid_if"
-          label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input
-          name="hintText"
-          inner-label="Hint Text"
-          value="${
-            config.hintText
+            config.innerLabel
           }">
         </tangy-input>
         <tangy-input
@@ -156,15 +110,6 @@ class TangyNumberWidget extends TangyBaseWidget {
             config.max
           }">
         </tangy-input>
-        <tangy-checkbox name="required" ${
-          config.required ? 'value="on"' : ''
-        }>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${
-          config.disabled ? 'value="on"' : ''
-        }>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${
-          config.hidden ? 'value="on"' : ''
-        }>Hidden</tangy-checkbox>
       </tangy-form-item>
     </tangy-form>
     `;
@@ -173,40 +118,19 @@ class TangyNumberWidget extends TangyBaseWidget {
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
-        .value,
-      label: formEl.response.items[0].inputs.find(
-        input => input.name === 'label'
-      ).value,
+      ...this.onSubmitCommonAttributes(config, formEl),
+      ...this.onSubmitLabelAttributes(config, formEl),
       min: formEl.values.min,
       max: formEl.values.max,
-      hintText: formEl.values.hintText,
-      required:
-        formEl.response.items[0].inputs.find(input => input.name === 'required')
-          .value === 'on'
-          ? true
-          : false,
-      hidden:
-        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
-          .value === 'on'
-          ? true
-          : false,
-      disabled:
-        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
-          .value === 'on'
-          ? true
-          : false,
+      innerLabel: formEl.response.items[0].inputs.find(
+        input => input.name === 'inner_label'
+      ).value,
       allowedPattern: formEl.response.items[0].inputs.find(
         input => input.name === 'allowed_pattern'
-      ).value,
-      tangyIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'tangy_if'
-      ).value,
-      validIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'valid_if'
       ).value
-    };
+    }
   }
+
 }
 
 window.customElements.define('tangy-number-widget', TangyNumberWidget);

--- a/widget/tangy-partial-date-widget.js
+++ b/widget/tangy-partial-date-widget.js
@@ -7,19 +7,13 @@ import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyPartialDateWidget extends TangyBaseWidget {
   get claimElement() {
-    return 'tangy-partial-date';
+    return 'tangy-partial-date'
   }
 
   get defaultConfig() {
     return {
-      name: '',
-      label: '',
-      hintText: '',
-      required: true,
-      disabled: false,
-      hidden: false,
-      tangyIf: '',
-      validIf: '',
+      ...this.defaultConfigCommonAttributes(),
+      ...this.defaultConfigLabelAttributes(),
       futureDateErrorText: '',
       missingDateErrorText: '',
       invalidDateErrorText: '',
@@ -31,40 +25,28 @@ class TangyPartialDateWidget extends TangyBaseWidget {
       allowUnknownMonth: false,
       allowUnknownYear: false,
       showTodayButton: true
-    };
+    }
   }
 
   upcast(config, element) {
-    // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
     return {
-      ...config,
-      ...element.getProps(),
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-        : '',
-      validIf: element.hasAttribute('valid-if')
-        ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-        : ''
-    };
+      ...this.upcastCommonAttributes(config, element),
+      ...this.upcastLabelAttributes(config, element),
+      ...element.getProps()
+    }
   }
 
   downcast(config) {
     return `
       <tangy-partial-date
-        name="${config.name}"
-        label="${config.label}"
-        hint-text="${config.hintText}"
+        ${this.downcastCommonAttributes(config)}
+        ${this.downcastLabelAttributes(config)}
         future-date-error-text="${config.futureDateErrorText}"
         missing-date-error-text="${config.missingDateErrorText}"
         invalid-date-error-text="${config.invalidDateErrorText}"
         question-number="${config.questionNumber}"
         min-year="${config.minYear}"
         max-year="${config.maxYear}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
         ${config.showTodayButton ? 'show-today-button' : ''}
         ${config.allowUnknownDay ? 'allow-unknown-day' : ''}
         ${config.allowUnknownMonth ? 'allow-unknown-month' : ''}
@@ -106,172 +88,90 @@ class TangyPartialDateWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add Partial Date</h2>
-    <tangy-form id="tangy-partial-date">
-      <tangy-form-item id="tangy-partial-date">
-        <template type="tangy-form-item">
-
-        <h3>General Settings</h3>
-        
-          <tangy-input
-            name="name"
-            valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-            inner-label="Variable name"
-            hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-            value="${config.name}"
-            required>
-          </tangy-input>
-
-          <tangy-input
-            name="question-number"
-            inner-label="Question number"
-            hint-text="Enter the question number"
-            value="${config.questionNumber}">
-          </tangy-input>
-
-          <tangy-input
-            name="label"
-            inner-label="Label"
-            hint-text="Enter the Question or Statement Text"
-            value="${config.label}">
-          </tangy-input>
-
-          <tangy-input
-            name="hintText"
-            inner-label="Hint text"
-            hint-text="Enter hint text."
-            value="${config.hintText}">
-          </tangy-input>
-
-          <tangy-input
-            name="tangy_if"
-            inner-label="Show if"
-            hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-            value="${config.tangyIf.replace(/"/g, '&quot;')}">
-          </tangy-input>
-
-          <tangy-input
-            name="valid_if"
-            inner-label="Valid if"
-            hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-            value="${config.validIf.replace(/"/g, '&quot;')}">
-          </tangy-input>
-
-          <br>
-
-          <h3>General Configuration</h3>
-
-          <tangy-checkbox 
-            name="required" 
-            ${config.required ? 'value="on"' : ''}>
-            Required
-          </tangy-checkbox>
-
-          <tangy-checkbox
-            name="disabled"
-            ${config.disabled ? 'value="on"' : ''}>
-            Disabled
-          </tangy-checkbox>
-
-          <tangy-checkbox
-            name="hidden" ${config.hidden ? 'value="on"' : ''}>
-            Hidden
-          </tangy-checkbox>
-
-          <tangy-checkbox
-            name="show-today-button"
-            ${config.showTodayButton ? 'value="on"' : ''}>
-            Show today button
-          </tangy-checkbox>
-
-          <br>
-
-          <h3>Date Behavior</h3>
-      
-          <tangy-checkbox
-            name="allow-unknown-day"
-            ${config.allowUnknownDay ? 'value="on"' : ''}>
-            Allow unknown day
-          </tangy-checkbox>
-
-          <tangy-checkbox
-            name="allow-unknown-month"
-            ${config.allowUnknownMonth ? 'value="on"' : ''}>
-            Allow unknown month
-          </tangy-checkbox>
-
-          <tangy-checkbox
-            name="allow-unknown-year" 
-            ${config.allowUnknownYear ? 'value="on"' : ''}>
-            Allow unknown year
-          </tangy-checkbox>
-
-          <tangy-checkbox
-            name="disallow-future-date"
-            ${config.disallowFutureDate ? 'value="on"' : ''}>
-            Disallow future date
-          </tangy-checkbox>
-
-          <br>
-
-          <h3>Error Messages</h3>
-
-         <tangy-input
-            name="missing-date-error-text"
-            inner-label="Missing date error text"
-            hint-text="Enter text to be displayed when the date is required but missing."
-            value="${config.missingDateErrorText.replace(/"/g, '&quot;')}">
-          </tangy-input>
-
-          <tangy-input
-            name="invalid-date-error-text"
-            inner-label="Invalid date error text"
-            hint-text="Enter text to be displayed when the date is invalid."
-            value="${config.invalidDateErrorText.replace(/"/g, '&quot;')}">
-          </tangy-input>
-
-          <tangy-input
-            name="future-date-error-text"
-            inner-label="Future date error text"
-            hint-text="Enter text to be displayed when the date is in the future."
-            value="${config.futureDateErrorText.replace(/"/g, '&quot;')}">
-          </tangy-input>
-           
-          <br>
-
-          <h3>Validation</h3>
-
-          <tangy-input
-            name="min-year"
-            inner-label="Minimum year"
-            hint-text="Enter minimum year for the dropdowm list."
-            value="${config.minYear}">
-          </tangy-input>
-
-          <tangy-input
-            name="max-year"
-            inner-label="Maximum year"
-            hint-text="Enter maximum year for the dropdown list."
-            value="${config.maxYear}">
-          </tangy-input>
-
-        </template>
-      </tangy-form-item>
-    </tangy-form>
-    `;
+    return `
+      <tangy-form id="tangy-partial-date">
+        <tangy-form-item id="tangy-partial-date">
+          <template type="tangy-form-item">
+            <h3>General Settings</h3>
+            ${this.renderEditCommonAttributes(config)}
+            ${this.renderEditLabelAttributes(config)}
+            <tangy-input
+              name="question-number"
+              inner-label="Question number"
+              hint-text="Enter the question number"
+              value="${config.questionNumber}">
+            </tangy-input>
+            <h3>Date Behavior</h3>
+            <tangy-checkbox
+              name="show-today-button"
+              ${config.showTodayButton ? 'value="on"' : ''}>
+              Show today button
+            </tangy-checkbox>
+            <br>
+            <tangy-checkbox
+              name="allow-unknown-day"
+              ${config.allowUnknownDay ? 'value="on"' : ''}>
+              Allow unknown day
+            </tangy-checkbox>
+            <tangy-checkbox
+              name="allow-unknown-month"
+              ${config.allowUnknownMonth ? 'value="on"' : ''}>
+              Allow unknown month
+            </tangy-checkbox>
+            <tangy-checkbox
+              name="allow-unknown-year" 
+              ${config.allowUnknownYear ? 'value="on"' : ''}>
+              Allow unknown year
+            </tangy-checkbox>
+            <tangy-checkbox
+              name="disallow-future-date"
+              ${config.disallowFutureDate ? 'value="on"' : ''}>
+              Disallow future date
+            </tangy-checkbox>
+            <br>
+            <h3>Error Messages</h3>
+            <tangy-input
+              name="missing-date-error-text"
+              inner-label="Missing date error text"
+              hint-text="Enter text to be displayed when the date is required but missing."
+              value="${config.missingDateErrorText.replace(/"/g, '&quot;')}">
+            </tangy-input>
+            <tangy-input
+              name="invalid-date-error-text"
+              inner-label="Invalid date error text"
+              hint-text="Enter text to be displayed when the date is invalid."
+              value="${config.invalidDateErrorText.replace(/"/g, '&quot;')}">
+            </tangy-input>
+            <tangy-input
+              name="future-date-error-text"
+              inner-label="Future date error text"
+              hint-text="Enter text to be displayed when the date is in the future."
+              value="${config.futureDateErrorText.replace(/"/g, '&quot;')}">
+            </tangy-input>
+            <br>
+            <h3>Validation</h3>
+            <tangy-input
+              name="min-year"
+              inner-label="Minimum year"
+              hint-text="Enter minimum year for the dropdowm list."
+              value="${config.minYear}">
+            </tangy-input>
+            <tangy-input
+              name="max-year"
+              inner-label="Maximum year"
+              hint-text="Enter maximum year for the dropdown list."
+              value="${config.maxYear}">
+            </tangy-input>
+          </template>
+        </tangy-form-item>
+      </tangy-form>
+    `
   }
 
   onSubmit(config, formEl) {
     return {
-      ...config,
-      name: formEl.values.name,
-      label: formEl.values.label,
-      tangyIf: formEl.values.tangy_if,
-      validIf: formEl.values.valid_if,
-      required: formEl.values.required === 'on' ? true : false,
-      hintText: formEl.values.hintText,
-      hidden: formEl.values.hidden === 'on' ? true : false,
-      disabled: formEl.values.disabled === 'on' ? true : false,
+      ...this.onSubmitCommonAttributes(config, formEl),
+      ...this.onSubmitLabelAttributes(config, formEl),
       disallowFutureDate: formEl.values['disallow-future-date'] === 'on' ? true : false,
       allowUnknownDay: formEl.values['allow-unknown-day'] === 'on' ? true : false,
       allowUnknownMonth: formEl.values['allow-unknown-month'] === 'on' ? true : false,

--- a/widget/tangy-qr-widget.js
+++ b/widget/tangy-qr-widget.js
@@ -5,54 +5,34 @@ import 'tangy-form/input/tangy-checkbox.js';
 import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyQrWidget extends TangyBaseWidget {
+
   get claimElement() {
     return 'tangy-qr';
   }
 
   get defaultConfig() {
     return {
-      name: '',
-      required: false,
-      disabled: false,
-      hidden: false,
-      tangyIf: '',
-      validIf: ''
+      ...this.defaultConfigCommonAttributes()
     };
   }
 
   upcast(config, element) {
-    // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyQr.props thus won't get picked up by TangyQr.getProps().
     return {
-      ...config,
-      ...element.getProps(),
-      ...{
-        tangyIf: element.hasAttribute('tangy-if')
-          ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-          : '',
-        validIf: element.hasAttribute('valid-if')
-          ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-          : ''
-      }
+      ...this.upcastCommonAttributes(config, element)
     };
   }
 
   downcast(config) {
     return `
       <tangy-qr 
-        name="${config.name}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
+        ${this.downcastCommonAttributes(config)}
       >
-        ${config.metaDataTemplate}
       </tangy-qr>
     `;
   }
+
   renderPrint(config) {
     return `
-
     <table>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
       <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
@@ -62,6 +42,7 @@ class TangyQrWidget extends TangyBaseWidget {
     <hr/>
     `;
   }
+
   renderInfo(config) {
     const icon = this.shadowRoot.querySelector('#icon').innerHTML=`<span class="header-text"><mwc-icon>filter_center_focus</mwc-icon><span>`
     const name = this.shadowRoot.querySelector('#name').innerHTML=`<span class="header-text">${config.name}</span>`
@@ -69,72 +50,21 @@ class TangyQrWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add QR Scanner</h2>
-    <tangy-form id="tangy-qr">
-      <tangy-form-item>
-        <tangy-input
-          name="name"
-          valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-          inner-label="Variable name" 
-          value="${
-            config.name
-          }"
-          required>
-        </tangy-input>
-        <tangy-input 
-          name="tangy_if"
-          inner-label="Show if"
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input
-          name="valid_if"
-          inner-label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-checkbox name="required" ${
-          config.required ? 'value="on"' : ''
-        }>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${
-          config.disabled ? 'value="on"' : ''
-        }>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${
-          config.hidden ? 'value="on"' : ''
-        }>Hidden</tangy-checkbox>
-      </tangy-form-item>
-    </tangy-form>
+    return `
+      <tangy-form id="tangy-qr">
+        <tangy-form-item>
+          ${this.renderEditCommonAttributes(config)}
+        </tangy-form-item>
+      </tangy-form>
     `;
   }
 
   onSubmit(config, formEl) {
     return {
-      ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
-        .value,
-      required:
-        formEl.response.items[0].inputs.find(input => input.name === 'required')
-          .value === 'on'
-          ? true
-          : false,
-      hidden:
-        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
-          .value === 'on'
-          ? true
-          : false,
-      disabled:
-        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
-          .value === 'on'
-          ? true
-          : false,
-      tangyIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'tangy_if'
-      ).value,
-      validIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'valid_if'
-      ).value
-    };
+      ...this.onSubmitCommonAttributes(config, formEl),
+    }
   }
+
 }
 
 window.customElements.define('tangy-qr-widget', TangyQrWidget);

--- a/widget/tangy-radio-buttons-widget.js
+++ b/widget/tangy-radio-buttons-widget.js
@@ -7,67 +7,46 @@ import 'tangy-form/input/tangy-checkbox.js';
 import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyRadioButtonsWidget extends TangyBaseWidget {
+
   get claimElement() {
-    return 'tangy-radio-buttons';
+    return 'tangy-radio-buttons'
   }
 
   get defaultConfig() {
     return {
-      name: '',
-      label: '',
-      hintText: '',
-      options: [],
-      required: false,
-      disabled: false,
-      hidden: false,
-      tangyIf: '',
-      validIf: ''
-    };
+      ...this.defaultConfigCommonAttributes(),
+      ...this.defaultConfigLabelAttributes(),
+      options: []
+    }
   }
 
   upcast(config, element) {
-    // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
     return {
-      ...config,
-      ...element.getProps(),
+      ...this.upcastCommonAttributes(config, element),
+      ...this.upcastLabelAttributes(config, element),
       options: [...element.querySelectorAll('option')].map(option => {
         return {
           value: option.getAttribute('value'),
           label: option.innerHTML,
           correct: option.hasAttribute('correct')
-        };
-      }),
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-        : '',
-      validIf: element.hasAttribute('valid-if')
-        ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-        : ''
-    };
+        }
+      })
+    }
   }
 
   downcast(config) {
     return `
       <tangy-radio-buttons
-        name="${config.name}"
-        label="${config.label}"
-        hint-text="${config.hintText}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
+        ${this.downcastCommonAttributes(config)}
+        ${this.downcastLabelAttributes(config)}
       >
-       ${config.options
-         .map(
-           option => `
-       <option value="${option.value}" ${option.correct ? 'correct' : ''} >${option.label}</option>
-      `
-         )
-         .join('')}
+        ${config.options.map(option => `
+          <option value="${option.value}" ${option.correct ? 'correct' : ''} >${option.label}</option>
+        `).join('')}
       </tangy-radio-buttons>
-    `;
+    `
   }
+
   renderPrint(config) {
     let keyValuePairs = '';
     config.options.map(option => {
@@ -87,6 +66,7 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
     <hr/>
     `;
   }
+
   renderInfo(config) {
     const icon = this.shadowRoot.querySelector('#icon').innerHTML=`<span class="header-text"><mwc-icon>filter_center_focus</mwc-icon><span>`
     const name = this.shadowRoot.querySelector('#name').innerHTML=`<span class="header-text">${config.name}</span>`
@@ -97,52 +77,9 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
     return `<h2>Add Radio Buttons</h2>
     <tangy-form id="tangy-radio-buttons">
       <tangy-form-item id="tangy-radio-buttons">
-        <template type="tangy-form-item">
-          <tangy-input
-            name="name"
-            valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-            hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-            inner-label="Variable name" value="${
-              config.name
-            }"
-            required>
-          </tangy-input>
-          <tangy-input
-            name="label"
-            inner-label="Label"
-            hint-text="Enter the Question or Statement Text"
-            value="${
-              config.label
-            }">
-          </tangy-input>
-          <tangy-input
-            name="hintText"
-            inner-label="Hint Text"
-            value="${
-              config.hintText
-            }">
-          </tangy-input>
-          <tangy-input
-            name="tangy_if"
-            inner-label="Show if"
-            hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-            value="${config.tangyIf.replace(/"/g, '&quot;')}">
-          </tangy-input>
-          <tangy-input
-            name="valid_if"
-            inner-label="Valid if"
-            hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-            value="${config.validIf.replace(/"/g, '&quot;')}">
-          </tangy-input>
-          <tangy-checkbox name="required" ${
-            config.required ? 'value="on"' : ''
-          }>Required</tangy-checkbox>
-          <tangy-checkbox name="disabled" ${
-            config.disabled ? 'value="on"' : ''
-          }>Disabled</tangy-checkbox>
-          <tangy-checkbox name="hidden" ${
-            config.hidden ? 'value="on"' : ''
-          }>Hidden</tangy-checkbox>
+        <template>
+          ${this.renderEditCommonAttributes(config)}
+          ${this.renderEditLabelAttributes(config)}
           <h2>Options</h2>
           <p>Click the "Correct" property for options that are the correct answer. This property is used with the Section Detail's Threshold property.</p>
           <tangy-list name="options">
@@ -151,29 +88,17 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
               <tangy-input name="label" hint-text="Enter the display label of the radio button" inner-label="Label" type="text"></tangy-input>
               <tangy-checkbox name="correct" hint-text="Select if this is the correct answer."  label="Correct" ></tangy-checkbox>
             </template>
-            ${
-              config.options.length > 0
-                ? `
-            <template type="tangy-list/initial-items">
-              ${config.options
-                .map(
-                  option => `
-                <tangy-list-item>
-                  <tangy-input name="value" allowed-pattern="[a-zA-Z0-9\-_]" hint-text="Enter the variable value of the radio button" inner-label="Value" type="text" value="${
-                    option.value
-                  }"></tangy-input>
-                  <tangy-input name="label" hint-text="Enter the display label of the radio button" inner-label="Label" type="text" value="${
-                    option.label
-                  }"></tangy-input>
-                  <tangy-checkbox name="correct" hint-text="Select if this is the correct answer."  label="Correct"  value="${option.correct ? 'on' : ''}"></tangy-checkbox>
-                </tangy-list-item>
-              `
-                )
-                .join('')}
-            </template>
-            `
-                : ''
-            }
+            ${config.options.length > 0 ? `
+              <template type="tangy-list/initial-items">
+                ${config.options.map(option => `
+                  <tangy-list-item>
+                    <tangy-input name="value" allowed-pattern="[a-zA-Z0-9\-_]" hint-text="Enter the variable value of the radio button" inner-label="Value" type="text" value="${option.value}"></tangy-input>
+                    <tangy-input name="label" hint-text="Enter the display label of the radio button" inner-label="Label" type="text" value="${option.label}"></tangy-input>
+                    <tangy-checkbox name="correct" hint-text="Select if this is the correct answer."  label="Correct"  value="${option.correct ? 'on' : ''}"></tangy-checkbox>
+                  </tangy-list-item>
+                `).join('')}
+              </template>
+            ` : ''}
           </tangy-list>
         </template>
       </tangy-form-item>
@@ -181,40 +106,10 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
     `;
   }
 
-  editResponse(config) {
-    return {
-      form: {
-        complete: false
-      },
-      items: [
-        {
-          id: 'tangy-radio-buttons',
-          inputs: [
-            {
-              name: 'name',
-              value: config.name
-            },
-            {
-              name: 'label',
-              value: config.label
-            }
-          ]
-        }
-      ]
-    };
-  }
-
   onSubmit(config, formEl) {
     return {
-      ...config,
-      name: formEl.values.name,
-      label: formEl.values.label,
-      tangyIf: formEl.values.tangy_if,
-      validIf: formEl.values.valid_if,
-      required: formEl.values.required === 'on' ? true : false,
-      hintText: formEl.values.hintText,
-      hidden: formEl.values.hidden === 'on' ? true : false,
-      disabled: formEl.values.disabled === 'on' ? true : false,
+      ...this.onSubmitCommonAttributes(config, formEl),
+      ...this.onSubmitLabelAttributes(config, formEl),
       options: formEl.values.options.map(item =>
         item.reduce((acc, input) => {
           return { ...acc, [input.name]: input.value };
@@ -222,6 +117,7 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
       )
     };
   }
+
 }
 
 window.customElements.define(

--- a/widget/tangy-select-widget.js
+++ b/widget/tangy-select-widget.js
@@ -6,73 +6,51 @@ import 'tangy-form/input/tangy-input.js';
 import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangySelectWidget extends TangyBaseWidget {
+
   get claimElement() {
-    return 'tangy-select';
+    return 'tangy-select'
   }
 
   get defaultConfig() {
     return {
-      name: '',
-      label: '',
-      hintText: '',
-      options: [],
-      required: false,
-      disabled: false,
-      hidden: false,
-      tangyIf: '',
-      validIf: ''
-    };
+      ...this.defaultConfigCommonAttributes(),
+      ...this.defaultConfigLabelAttributes(),
+      options: []
+    }
   }
 
   upcast(config, element) {
-    // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
     return {
-      ...config,
-      ...element.getProps(),
+      ...this.upcastCommonAttributes(config, element),
+      ...this.upcastLabelAttributes(config, element),
       options: [...element.querySelectorAll('option')].map(option => {
         return {
           value: option.getAttribute('value'),
           label: option.innerHTML
-        };
-      }),
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-        : '',
-      validIf: element.hasAttribute('valid-if')
-        ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-        : ''
-    };
+        }
+      })
+    }
   }
 
   downcast(config) {
     return `
       <tangy-select
-        name="${config.name}"
-        label="${config.label}"
-        hint-text="${config.hintText}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
+        ${this.downcastCommonAttributes(config)}
+        ${this.downcastLabelAttributes(config)}
       >
-       ${config.options
-         .map(
-           option => `
-         <option value="${option.value}">${option.label}</option>
-      `
-         )
-         .join('')}
+        ${config.options.map(option => `
+          <option value="${option.value}">${option.label}</option>
+        `).join('')}
       </tangy-select>
-    `;
+    `
   }
+
   renderPrint(config) {
     let keyValuePairs = '';
     config.options.map(option => {
       keyValuePairs += `<li>${option.value}: ${option.label}</li>`;
     });
     return `
-   
     <table>
       <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
       <tr><td><strong>Secondary Label:</strong></td><td>${
@@ -88,6 +66,7 @@ class TangySelectWidget extends TangyBaseWidget {
     <hr/>
     `;
   }
+
   renderInfo(config) {
     const icon = this.shadowRoot.querySelector('#icon').innerHTML=`<span class="header-text"><mwc-icon>looks_one</mwc-icon><span>`
     const name = this.shadowRoot.querySelector('#name').innerHTML=`<span class="header-text">${config.name}</span>`
@@ -95,127 +74,46 @@ class TangySelectWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add Dropdown</h2>
-    <tangy-form id="tangy-select">
-      <tangy-form-item id="tangy-select">
-        <template type="tangy-form-item">
-          <tangy-input
-            name="name"
-            valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-            inner-label="Variable name"
-            hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-            value="${
-              config.name
-            }"
-            required>
-          </tangy-input>
-          <tangy-input
-            name="label"
-            inner-label="Label"
-            hint-text="Enter the Question or Statement Text"
-            value="${
-              config.label
-            }">
-          </tangy-input>
-          <tangy-input name="hintText" inner-label="Hint Text" value="${
-            config.hintText
-          }"></tangy-input>
-          <tangy-input
-            name="tangy_if"
-            inner-label="Show if"
-            hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-            value="${config.tangyIf.replace(/"/g, '&quot;')}">
-          </tangy-input>
-          <tangy-input
-            name="valid_if"
-            label="Valid if"
-            hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-            value="${config.validIf.replace(/"/g, '&quot;')}">
-          </tangy-input>
-          <tangy-checkbox name="required" ${
-            config.required ? 'value="on"' : ''
-          }>Required</tangy-checkbox>
-          <tangy-checkbox name="disabled" ${
-            config.disabled ? 'value="on"' : ''
-          }>Disabled</tangy-checkbox>
-          <tangy-checkbox name="hidden" ${
-            config.hidden ? 'value="on"' : ''
-          }>Hidden</tangy-checkbox>
-          <tangy-list name="options">
-            <template type="tangy-list/new-item">
-              <tangy-input name="value" hint-text="Enter the variable name of this drop-down option." allowed-pattern="[a-zA-Z0-9\-_]" inner-label="Value" type="text"></tangy-input>
-              <tangy-input name="label" hint-text="Enter the label for this drop-down option." label="Label" type="text"></tangy-input>
-            </template>
-            ${
-              config.options.length > 0
-                ? `
-            <template type="tangy-list/initial-items">
-              ${config.options
-                .map(
-                  option => `
-                <tangy-list-item>
-                  <tangy-input hint-text="Enter the variable name of this drop-down option." name="value" allowed-pattern="[a-zA-Z0-9\-_]" label="Value" type="text" value="${
-                    option.value
-                  }"></tangy-input>
-                  <tangy-input hint-text="Enter the label for this drop-down option." name="label" label="Label" type="text" value="${
-                    option.label
-                  }"></tangy-input>
-                </tangy-list-item>
-              `
-                )
-                .join('')}
-            </template>
-            `
-                : ''
-            }
-          </tangy-list>
-        </template>
-      </tangy-form-item>
-    </tangy-form>
-    `;
-  }
-
-  editResponse(config) {
-    return {
-      form: {
-        complete: false
-      },
-      items: [
-        {
-          id: 'tangy-select',
-          inputs: [
-            {
-              name: 'name',
-              value: config.name
-            },
-            {
-              name: 'label',
-              value: config.label
-            }
-          ]
-        }
-      ]
-    };
+    return `
+      <tangy-form id="tangy-select">
+        <tangy-form-item id="tangy-select">
+          <template>
+            ${this.renderEditCommonAttributes(config)}
+            ${this.renderEditLabelAttributes(config)}
+            <tangy-list name="options">
+              <template type="tangy-list/new-item">
+                <tangy-input name="value" hint-text="Enter the variable name of this drop-down option." allowed-pattern="[a-zA-Z0-9\-_]" inner-label="Value" type="text"></tangy-input>
+                <tangy-input name="label" hint-text="Enter the label for this drop-down option." label="Label" type="text"></tangy-input>
+              </template>
+              ${config.options.length > 0 ? `
+                <template type="tangy-list/initial-items">
+                  ${config.options.map(option => `
+                    <tangy-list-item>
+                      <tangy-input hint-text="Enter the variable name of this drop-down option." name="value" allowed-pattern="[a-zA-Z0-9\-_]" label="Value" type="text" value="${option.value}"></tangy-input>
+                      <tangy-input hint-text="Enter the label for this drop-down option." name="label" label="Label" type="text" value="${option.label}"></tangy-input>
+                    </tangy-list-item>  
+                  `).join('')}
+                </template>
+              `: ''}
+            </tangy-list>
+          </template>
+        </tangy-form-item>
+      </tangy-form>
+    `
   }
 
   onSubmit(config, formEl) {
     return {
-      ...config,
-      name: formEl.values.name,
-      label: formEl.values.label,
-      tangyIf: formEl.values.tangy_if,
-      validIf: formEl.values.valid_if,
-      required: formEl.values.required === 'on' ? true : false,
-      hintText: formEl.values.hintText,
-      hidden: formEl.values.hidden === 'on' ? true : false,
-      disabled: formEl.values.disabled === 'on' ? true : false,
+      ...this.onSubmitCommonAttributes(config, formEl),
+      ...this.onSubmitLabelAttributes(config, formEl),
       options: formEl.values.options.map(item =>
         item.reduce((acc, input) => {
-          return { ...acc, [input.name]: input.value };
+          return { ...acc, [input.name]: input.value }
         }, {})
       )
-    };
+    }
   }
+
 }
 
 window.customElements.define('tangy-select-widget', TangySelectWidget);

--- a/widget/tangy-template-widget.js
+++ b/widget/tangy-template-widget.js
@@ -11,39 +11,23 @@ class TangyTemplateWidget extends TangyBaseWidget {
 
   get defaultConfig() {
     return {
-      name: '',
-      required: false,
-      disabled: false,
-      hidden: false,
-      tangyIf: '',
-      validIf: '',
+      ...this.defaultConfigCommonAttributes(),
       htmlCode:  ''
     }
   }
 
   upcast(config, element) {
     // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyTemplate.props thus won't get picked up by TangyTemplate.getProps().
-    return {...config,
-      ...element.getProps(),
-      htmlCode: element.innerHTML,
-      tangyIf: element.hasAttribute('tangy-if')
-        ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-        : '',
-      validIf: element.hasAttribute('valid-if')
-        ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-        : ''
+    return {
+      ...this.upcastCommonAttributes(config, element),
+      htmlCode: element.innerHTML
     }
   }
 
   downcast(config) {
     return `
       <tangy-template 
-        name="${config.name}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
+        ${this.downcastCommonAttributes(config)}
       >${config.htmlCode}</tangy-template>
     `
   }
@@ -55,48 +39,21 @@ class TangyTemplateWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add Template content</h2>
-    <tangy-form id="tangy-input">
-      <tangy-form-item>
-        <tangy-input 
-          name="name" 
-          valid-if="input.value && input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-          hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-          inner-label="Enter the variable name you would like displayed on all data outputs (e.g. employee_id)."
-          value="${config.name}" 
-          required>
-        </tangy-input>
-        <tangy-input 
-          name="tangy_if" 
-          inner-label="Show if" 
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input
-          name="valid_if"
-          inner-label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-checkbox name="required" ${config.required ? 'value="on"' : ''}>Required</tangy-checkbox>
-        <tangy-checkbox name="disabled" ${config.disabled ? 'value="on"' : ''}>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${config.hidden ? 'value="on"' : ''}>Hidden</tangy-checkbox>
-        <tangy-code mode="ace/mode/html" name="htmlCode" height="600" required>
-          ${config.htmlCode}
-        </tangy-code>
-      </tangy-form-item>
-    </tangy-form>
+    return `
+      <tangy-form id="tangy-input">
+        <tangy-form-item>
+          ${this.renderEditCommonAttributes(config)}
+          <tangy-code mode="ace/mode/html" name="htmlCode" height="600" required>
+            ${config.htmlCode}
+          </tangy-code>
+        </tangy-form-item>
+      </tangy-form>
     `
   }
 
   onSubmit(config, formEl) {
     return {
-      ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name').value,
-      hidden: formEl.response.items[0].inputs.find(input => input.name === 'hidden').value === 'on' ? true : false,
-      disabled: formEl.response.items[0].inputs.find(input => input.name === 'disabled').value === 'on' ? true : false,
-      tangyIf: formEl.response.items[0].inputs.find(input => input.name === 'tangy_if').value,
-      validIf: formEl.response.items[0].inputs.find(input => input.name === 'valid_if').value,
+      ...this.onSubmitCommonAttributes(config, formEl),
       htmlCode: formEl.response.items[0].inputs.find(input => input.name === 'htmlCode').value
     }
   }

--- a/widget/tangy-text-widget.js
+++ b/widget/tangy-text-widget.js
@@ -4,22 +4,22 @@ import 'tangy-form/input/tangy-select.js';
 import { TangyBaseWidget } from '../tangy-base-widget.js';
 
 class TangyTextWidget extends TangyBaseWidget {
+
   get claimElement() {
     return 'tangy-input[type=text], tangy-input:not([type])';
   }
+
   get defaultConfig() {
     return {
-      type: 'text',
-      allowedPattern: '',
-      innerLabel: '',
       ...this.defaultConfigCommonAttributes(),
-      ...this.defaultConfigLabelAttributes()
+      ...this.defaultConfigLabelAttributes(),
+      allowedPattern: '',
+      innerLabel: ''
     };
   }
 
   upcast(config, element) {
     return {
-      ...config,
       ...this.upcastCommonAttributes(config, element),
       ...this.upcastLabelAttributes(config, element),
       ...element.getProps()

--- a/widget/tangy-text-widget.js
+++ b/widget/tangy-text-widget.js
@@ -9,11 +9,11 @@ class TangyTextWidget extends TangyBaseWidget {
   }
   get defaultConfig() {
     return {
-      label: '',
-      hintText: '',
       type: 'text',
       allowedPattern: '',
-      ...this.defaultConfigCommonAttributes()
+      innerLabel: '',
+      ...this.defaultConfigCommonAttributes(),
+      ...this.defaultConfigLabelAttributes()
     };
   }
 
@@ -21,6 +21,7 @@ class TangyTextWidget extends TangyBaseWidget {
     return {
       ...config,
       ...this.upcastCommonAttributes(config, element),
+      ...this.upcastLabelAttributes(config, element),
       ...element.getProps()
     };
   }
@@ -28,11 +29,11 @@ class TangyTextWidget extends TangyBaseWidget {
   downcast(config) {
     return `
       <tangy-input 
-        label="${config.label}"
-        hint-text="${config.hintText}"
         type="text"
         allowed-pattern="${config.allowedPattern}"
+        inner-label="${config.innerLabel}"
         ${this.downcastCommonAttributes(config)}
+        ${this.downcastLabelAttributes(config)}
       ></tangy-input>
     `;
   }
@@ -70,16 +71,13 @@ class TangyTextWidget extends TangyBaseWidget {
     <tangy-form id="tangy-input">
       <tangy-form-item>
         ${this.renderEditCommonAttributes(config)}
+        ${this.renderEditLabelAttributes(config)}
         <tangy-input
-          name="label"
-          inner-label="Label"
-          hint-text="Enter the Question or Statement Text"
-          value="${config.label}">
-        </tangy-input>
-        <tangy-input
-          name="hintText"
-          inner-label="Hint Text"
-          value="${config.hintText}">
+          name="inner_label"
+          inner-label="Inner Label"
+          value="${
+            config.innerLabel
+          }">
         </tangy-input>
         <tangy-input
           name="allowed_pattern"
@@ -96,10 +94,10 @@ class TangyTextWidget extends TangyBaseWidget {
     return {
       ...config,
       ...this.onSubmitCommonAttributes(config, formEl),
-      label: formEl.response.items[0].inputs.find(
-        input => input.name === 'label'
+      ...this.onSubmitLabelAttributes(config, formEl),
+      innerLabel: formEl.response.items[0].inputs.find(
+        input => input.name === 'inner_label'
       ).value,
-      hintText: formEl.values.hintText,
       allowedPattern: formEl.response.items[0].inputs.find(
         input => input.name === 'allowed_pattern'
       ).value

--- a/widget/tangy-text-widget.js
+++ b/widget/tangy-text-widget.js
@@ -9,55 +9,36 @@ class TangyTextWidget extends TangyBaseWidget {
   }
   get defaultConfig() {
     return {
-      name: '',
       label: '',
       hintText: '',
       type: 'text',
-      required: false,
-      disabled: false,
-      hidden: false,
       allowedPattern: '',
-      tangyIf: '',
-      validIf: ''
+      ...this.defaultConfigCommonAttributes()
     };
   }
 
   upcast(config, element) {
-    // @TODO We have to do that final thing for tangyIf because it's not declared a prop in TangyInput.props thus won't get picked up by TangyInput.getProps().
     return {
       ...config,
-      ...element.getProps(),
-      ...{
-        tangyIf: element.hasAttribute('tangy-if')
-          ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-          : '',
-        validIf: element.hasAttribute('valid-if')
-          ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-          : ''
-      }
+      ...this.upcastCommonAttributes(config, element),
+      ...element.getProps()
     };
   }
 
   downcast(config) {
     return `
       <tangy-input 
-        name="${config.name}"
         label="${config.label}"
         hint-text="${config.hintText}"
         type="text"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.validIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
         allowed-pattern="${config.allowedPattern}"
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
+        ${this.downcastCommonAttributes(config)}
       ></tangy-input>
     `;
   }
 
   renderPrint(config) {
     return `
-   
     <table>
       <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
@@ -88,14 +69,7 @@ class TangyTextWidget extends TangyBaseWidget {
     return `<h2>Add Text Input</h2>
     <tangy-form id="tangy-input">
       <tangy-form-item>
-        <tangy-input 
-          name="name" 
-          valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)" 
-          inner-label="Variable name"
-          value="${config.name}"
-          hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-          required>
-        </tangy-input>
+        ${this.renderEditCommonAttributes(config)}
         <tangy-input
           name="label"
           inner-label="Label"
@@ -113,33 +87,6 @@ class TangyTextWidget extends TangyBaseWidget {
           hint-text="Optional Javascript RegExp pattern to validate text (e.g. minimum length of 5 characters would be [a-zA-Z]{5,})
           value="${config.allowedPattern}">
         </tangy-input>
-        <tangy-input
-          name="tangy_if"
-          inner-label="Show if"
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input 
-          name="valid_if"
-          inner-label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-checkbox
-          name="required" 
-          ${config.required ? 'value="on"' : ''}>
-          Required
-        </tangy-checkbox>
-        <tangy-checkbox
-          name="disabled" 
-          ${config.disabled ? 'value="on"' : ''}>
-          Disabled
-        </tangy-checkbox>
-        <tangy-checkbox
-          name="hidden"
-          ${config.hidden ? 'value="on"' : ''}>
-          Hidden
-        </tangy-checkbox>
       </tangy-form-item>
     </tangy-form>
     `;
@@ -148,35 +95,13 @@ class TangyTextWidget extends TangyBaseWidget {
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
-        .value,
+      ...this.onSubmitCommonAttributes(config, formEl),
       label: formEl.response.items[0].inputs.find(
         input => input.name === 'label'
       ).value,
       hintText: formEl.values.hintText,
-      required:
-        formEl.response.items[0].inputs.find(input => input.name === 'required')
-          .value === 'on'
-          ? true
-          : false,
-      hidden:
-        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
-          .value === 'on'
-          ? true
-          : false,
-      disabled:
-        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
-          .value === 'on'
-          ? true
-          : false,
       allowedPattern: formEl.response.items[0].inputs.find(
         input => input.name === 'allowed_pattern'
-      ).value,
-      validIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'valid_if'
-      ).value,
-      tangyIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'tangy_if'
       ).value
     };
   }

--- a/widget/tangy-time-widget.js
+++ b/widget/tangy-time-widget.js
@@ -10,15 +10,9 @@ class TangyTimeWidget extends TangyBaseWidget {
 
   get defaultConfig() {
     return {
-      name: '',
-      label: '',
+      ...this.defaultConfigCommonAttributes(),
+      ...this.defaultConfigLabelAttributes(),
       type: 'time',
-      required: false,
-      disabled: false,
-      hidden: false,
-      hintText: '',
-      tangyIf: '',
-      validIf: ''
     };
   }
 
@@ -27,35 +21,23 @@ class TangyTimeWidget extends TangyBaseWidget {
     return {
       ...config,
       ...element.getProps(),
-      ...{
-        tangyIf: element.hasAttribute('tangy-if')
-          ? element.getAttribute('tangy-if').replace(/&quot;/g, '"')
-          : '',
-        validIf: element.hasAttribute('valid-if')
-          ? element.getAttribute('valid-if').replace(/&quot;/g, '"')
-          : ''
-      }
+      ...this.upcastCommonAttributes(config, element),
+      ...this.upcastLabelAttributes(config, element)
     };
   }
 
   downcast(config) {
     return `
       <tangy-input 
-        name="${config.name}"
-        label="${config.label}"
+        ${this.downcastCommonAttributes(config)}
+        ${this.downcastLabelAttributes(config)}
         type="time"
-        hint-text="${config.hintText}"
-        ${config.tangyIf === "" ? "" : `tangy-if="${config.tangyIf.replace(/"/g, '&quot;')}"`}
-        ${config.tangyIf === "" ? "" : `valid-if="${config.validIf.replace(/"/g, '&quot;')}"`}
-        ${config.required ? 'required' : ''}
-        ${config.disabled ? 'disabled' : ''}
-        ${config.hidden ? 'hidden' : ''}
       ></tangy-input>
     `;
   }
+
   renderPrint(config) {
     return `
-   
     <table>
       <tr><td><strong>Prompt:</strong></td><td>${config.label}</td></tr>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
@@ -72,6 +54,7 @@ class TangyTimeWidget extends TangyBaseWidget {
     <hr/>
     `;
   }
+
   renderInfo(config) {
     const icon = this.shadowRoot.querySelector('#icon').innerHTML=`<span class="header-text"><mwc-icon>timer</mwc-icon><span>`
     const name = this.shadowRoot.querySelector('#name').innerHTML=`<span class="header-text">${config.name}</span>`
@@ -79,88 +62,24 @@ class TangyTimeWidget extends TangyBaseWidget {
   }
 
   renderEdit(config) {
-    return `<h2>Add Time Input</h2>
-    <tangy-form id="tangy-time-widget">
-      <tangy-form-item>
-        <tangy-input 
-          name="name"
-          valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-          inner-label="Variable name"
-          hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
-          value="${
-            config.name
-          }"
-          required>
-        </tangy-input>
-        <tangy-input
-          name="label"
-          inner-label="Label"
-          hint-text="Enter the Question or Statement Text"
-          value="${
-            config.label
-          }">
-        </tangy-input>
-        <tangy-input name="hintText" inner-label="Hint Text" value="${
-          config.hintText
-        }"></tangy-input>
-        <tangy-input
-          name="tangy_if" 
-          inner-label="Show if"
-          hint-text="Enter any conditional display logic. (e.g. getValue('isEmployee') === true)"
-          value="${config.tangyIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-input
-          name="valid_if"
-          label="Valid if"
-          hint-text="Enter any conditional validation logic. (e.g. input.value.length > 5)"
-          value="${config.validIf.replace(/"/g, '&quot;')}">
-        </tangy-input>
-        <tangy-checkbox name="required" ${
-          config.required ? 'value="on"' : ''
-        }>Required</tangy-checkbox>
-       <tangy-checkbox name="disabled" ${
-          config.disabled ? 'value="on"' : ''
-        }>Disabled</tangy-checkbox>
-        <tangy-checkbox name="hidden" ${
-          config.hidden ? 'value="on"' : ''
-        }>Hidden</tangy-checkbox>
-      </tangy-form-item>
-    </tangy-form>
-    `;
+    return `
+      <tangy-form id="tangy-time-widget">
+        <tangy-form-item>
+          ${this.renderEditCommonAttributes(config)}
+          ${this.renderEditLabelAttributes(config)}
+        </tangy-form-item>
+      </tangy-form>
+    `
   }
 
   onSubmit(config, formEl) {
     return {
       ...config,
-      name: formEl.response.items[0].inputs.find(input => input.name === 'name')
-        .value,
-      label: formEl.response.items[0].inputs.find(
-        input => input.name === 'label'
-      ).value,
-      required:
-        formEl.response.items[0].inputs.find(input => input.name === 'required')
-          .value === 'on'
-          ? true
-          : false,
-      hintText: formEl.values.hintText,
-      hidden:
-        formEl.response.items[0].inputs.find(input => input.name === 'hidden')
-          .value === 'on'
-          ? true
-          : false,
-      disabled:
-        formEl.response.items[0].inputs.find(input => input.name === 'disabled')
-          .value === 'on'
-          ? true
-          : false,
-      tangyIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'tangy_if'
-      ).value,
-      validIf: formEl.response.items[0].inputs.find(
-        input => input.name === 'valid_if'
-      ).value
-    };
+      ...this.onSubmitCommonAttributes(config, formEl),
+      ...this.onSubmitLabelAttributes(config, formEl)
+    }
   }
+
 }
 
 window.customElements.define('tangy-time-widget', TangyTimeWidget);


### PR DESCRIPTION
This adds helper functions to the TangyBaseWidget class that saves tons of boilerplate to widgets that implement this class. See [this commit](https://github.com/Tangerine-Community/tangy-form-editor/pull/64/commits/c197d052ce03baf5d7e0335fc1aa32417fce5481) that implements using the helper methods in the text widget. Note, the helpers will facilitate changing `tangy-if` to the more epxressive `show-if` attribute automatically. We'll need to make sure references to `tangy-if`/`tangyIf` in tests are changed over to `showIf`/`show-if`.