### PR TITLE
Fix regex to allow for only valid variable names. 2 or more characters, begin with alpha, no spaces, periods, allow _ no dash

### DIFF
--- a/tangy-base-widget.js
+++ b/tangy-base-widget.js
@@ -191,10 +191,10 @@ class TangyBaseWidget extends PolymerElement {
     return `
       <tangy-input 
         name="name" 
-        valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)" 
+        valid-if="input.value.match(/^[a-zA-Z]{1,}[a-zA-Z0-9\_]{1,}$/)" 
         inner-label="Variable name"
         value="${config.name}"
-        hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
+        hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), and numbers (0-9)."
         required>
       </tangy-input>
       <tangy-input 

--- a/widget/tangy-image-widget.js
+++ b/widget/tangy-image-widget.js
@@ -57,8 +57,8 @@ class TangyImageWidget extends TangyBaseWidget {
       <tangy-form-item>
         <tangy-input 
           name="name" 
-          valid-if="input.value && input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)"
-          hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
+          valid-if="input.value && input.value.match(/^[a-zA-Z]{1,}[a-zA-Z0-9\_]{1,}$/)"
+          hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), and numbers (0-9)."
           inner-label="Enter the variable name you would like displayed on all data outputs (e.g. employee_id)."
           value="${config.name}" 
           required>

--- a/widget/tangy-timed-widget.js
+++ b/widget/tangy-timed-widget.js
@@ -116,8 +116,8 @@ class TangyTimedWidget extends TangyBaseWidget {
     <tangy-form id="tangy-timed">
       <tangy-form-item id="tangy-timed">
         <template type="tangy-form-item">
-          <tangy-input name="name" valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)" 
-            hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
+          <tangy-input name="name" valid-if="input.value.match(/^[a-zA-Z]{1,}[a-zA-Z0-9\_]{1,}$/)" 
+            hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), and numbers (0-9)."
             inner-label="Variable name" value="${
               config.name
             }" required></tangy-input>

--- a/widget/tangy-untimed-grid-widget.js
+++ b/widget/tangy-untimed-grid-widget.js
@@ -112,8 +112,8 @@ class TangyUntimedGridWidget extends TangyBaseWidget {
     <tangy-form id="tangy-untimed-grid">
       <tangy-form-item id="tangy-untimed-grid">
         <template type="tangy-form-item">
-          <tangy-input name="name" valid-if="input.value.match(/^[a-zA-Z].{1,}[a-zA-Z0-9\-_]$/)" 
-            hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), dash (-), and numbers (0-9)."
+          <tangy-input name="name" valid-if="input.value.match(/^[a-zA-Z]{1,}[a-zA-Z0-9\_]{1,}$/)"
+            hint-text="Enter the variable name that you would like displayed on all data outputs. Valid variable names start with a letter (a-z) with proceeding characters consisting of letters (a-z), underscore (_), and numbers (0-9)."
             inner-label="Variable name" value="${
               config.name
             }" required></tangy-input>


### PR DESCRIPTION
## Description
---
Valid variable names for an item should be valid `JavaScript identifiers`, but must begin with an alpha character ,i.e:
* must begin with Alpha character
* be 2 or more characters in length
* cannot contain periods(`.`), spaces, punctuation
* can contain underscores
* can contain integers

- Fixes 
 * Tangerine-Community/Tangerine#1461
 * Tangerine-Community/Tangerine#1558
 * Tangerine-Community/Tangerine#1566

## Type of Change
---
- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution
---
* Rewrite the `regex` for validating variable names to test for the conditions specified above.

## Limitations and Trade-offs
---
* N/A
## Screenshots/Videos
---
* [Link to GIF](https://recordit.co/LFIIhn2MYF)

## Tests
---
Tested the `regex` pattern online. [Link](https://regex101.com/)
