### PR TITLE
Labels for checkboxes and radio buttons should allow for HTML markup.

### DIFF
--- a/widget/tangy-checkboxes-widget.js
+++ b/widget/tangy-checkboxes-widget.js
@@ -115,7 +115,7 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
                     <template type="tangy-list/new-item">
                       <tangy-input name="value" allowed-pattern="[a-zA-Z0-9\-_]" inner-label="Value" hint-text="Enter the variable value if checkbox is chosen" type="text"></tangy-input>
                       <tangy-input name="label" inner-label="Label" hint-text="Enter the display label of the checkbox" type="text"></tangy-input>
-                      <tangy-checkbox name="mutuallyExclusive" hint-text="This option is mutually exlusive from the other options. If enabled, when this option is selected all other selections will be undone.">Mutually exlusive</tangy-checkbox>
+                      <tangy-checkbox name="mutuallyExclusive" hint-text="This option is mutually exclusive from the other options. If enabled, when this option is selected all other selections will be undone.">Mutually exlusive</tangy-checkbox>
                     </template>
                     ${
                       config.options.length > 0
@@ -129,11 +129,16 @@ class TangyCheckboxesWidget extends TangyBaseWidget {
                               option.value
                             }"></tangy-input>
                             <tangy-input name="label" hint-text="Enter the display label of the checkbox" inner-label="Label" type="text" value="${
-                              option.label
+                              option.label.
+                              replace(/&/g, "&amp;")
+                              .replace(/</g, "&lt;")
+                              .replace(/>/g, "&gt;")
+                              .replace(/"/g, "&quot;")
+                              .replace(/'/g, "&#039;")
                             }"></tangy-input>
                             <tangy-checkbox name="mutuallyExclusive" value="${
                               option.mutuallyExclusive ? "on" : ""
-                            }" hint-text="This option is mutually exlusive from the other options. If enabled, when this option is selected all other selections will be undone.">Mutually exlusive</tangy-checkbox>
+                            }" hint-text="This option is mutually exclusive from the other options. If enabled, when this option is selected all other selections will be undone.">Mutually exlusive</tangy-checkbox>
                           </tangy-list-item>  
                         `
                           )

--- a/widget/tangy-radio-buttons-widget.js
+++ b/widget/tangy-radio-buttons-widget.js
@@ -137,6 +137,11 @@ class TangyRadioButtonsWidget extends TangyBaseWidget {
                           }"></tangy-input>
                           <tangy-input name="label" hint-text="Enter the display label of the radio button" inner-label="Label" type="text" value="${
                             option.label
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;")
+                            .replace(/"/g, "&quot;")
+                            .replace(/'/g, "&#039;")
                           }"></tangy-input>
                           <tangy-checkbox name="correct" hint-text="Select if this is the correct answer."  label="Correct"  value="${
                             option.correct ? "on" : ""


### PR DESCRIPTION
Labels for checkboxes and radio buttons should allow for HTML markup.
This is achieved by escaping the content that is bound to the labels when doing a renderEdit
* Fixes https://github.com/Tangerine-Community/Tangerine/issues/2453