### PR TITLE
fix(tangy-form-editor): Persist changes when on-open and on-change ar…

### DIFF
--- a/tangy-form-item-editor.js
+++ b/tangy-form-item-editor.js
@@ -266,6 +266,12 @@ class TangyFormItemEditor extends PolymerElement {
       : "";
     onOpenEditorEl.style.height = `${window.innerHeight * 0.6}px`;
     onOpenEditorEl.addEventListener("change", (_) => _.stopPropagation());
+    const clearOnOpenLogicButton = document.createElement('div')
+    clearOnOpenLogicButton.innerHTML = `<paper-button id="clear-on-open-logic" class="tangy-action-buttons"> <iron-icon icon="delete"></iron-icon>${t("Clear On Open Logic")}</paper-button>`
+    this.shadowRoot
+      .querySelector("#on-open-editor")
+      .appendChild(clearOnOpenLogicButton);
+   
     this.shadowRoot
       .querySelector("#on-open-editor")
       .appendChild(onOpenEditorEl);
@@ -278,10 +284,21 @@ class TangyFormItemEditor extends PolymerElement {
       : "";
     onChangeEditorEl.style.height = `${window.innerHeight * 0.6}px`;
     onChangeEditorEl.addEventListener("change", (_) => _.stopPropagation());
+    const clearOnChangeLogicButton = document.createElement('div')
+    clearOnChangeLogicButton.innerHTML = `<paper-button id="clear-on-change-logic" class="tangy-action-buttons"> <iron-icon icon="delete"></iron-icon>${t("Clear On Change Logic")}</paper-button>`
+    
+    this.shadowRoot
+      .querySelector("#on-change-editor")
+      .appendChild(clearOnChangeLogicButton);
     this.shadowRoot
       .querySelector("#on-change-editor")
       .appendChild(onChangeEditorEl);
-
+    this.$.container
+    .querySelector("#clear-on-open-logic")
+    .addEventListener("click", this.clearOnOpenLogic.bind(this));
+    this.$.container
+    .querySelector("#clear-on-change-logic")
+    .addEventListener("click", this.clearOnChangeLogic.bind(this));
     // categories
     if (this.categories !== null && this.categories.length > 0) {
       let select_str =
@@ -371,7 +388,6 @@ class TangyFormItemEditor extends PolymerElement {
       this.shadowRoot.querySelector("#scoring-editor").innerHTML = ''
     }
   }
-
   save() {
     let templateEl = document.createElement("template");
     templateEl.innerHTML = this.shadowRoot.querySelector(
@@ -451,6 +467,15 @@ class TangyFormItemEditor extends PolymerElement {
           new CustomEvent("add-input", { bubbles: true, composed: true })
         )
       : this.$.container.querySelector(".card-content").removeChild(addInputEl);
+  }
+
+
+  clearOnOpenLogic(){
+   this.$.container.querySelector("#on-open-editor juicy-ace-editor").value = "  "
+  }
+
+  clearOnChangeLogic(){
+    this.$.container.querySelector("#on-change-editor juicy-ace-editor").value = "  "
   }
 }
 


### PR DESCRIPTION
Persist changes when on-open and on-change are cleared

Use a button to set the value of the textarea to a few space characters. This is a workaround to a bug in ace editor which doesnt allow setting the value to empty after it's value had been set to a non empty value

Refs https://github.com/Tangerine-Community/Tangerine/issues/3250