### PR TITLE
feat(scoring-section): Allow users to enter custom JavaScript code  for calculating scores

### DIFF
--- a/tangy-form-item-editor.js
+++ b/tangy-form-item-editor.js
@@ -429,9 +429,11 @@ class TangyFormItemEditor extends PolymerElement {
           onChange: this.shadowRoot
             .querySelector("#on-change-editor juicy-ace-editor")
             .value.replace(/"/g, "&#34;"),
-          customScoringLogic: this.shadowRoot
+          customScoringLogic:this.shadowRoot
           .querySelector("#custom-scoring-logic-editor juicy-ace-editor")
-          .value.replace(/"/g, "&#34;"),
+          ? this.shadowRoot
+          .querySelector("#custom-scoring-logic-editor juicy-ace-editor")
+          .value.replace(/"/g, "&#34;"):"",
           customScore:!selections.length? this.evaluateCustomScoringLogic(): '',
           category: categoryValue,
           title: this.$.container.querySelector("#itemTitle").value,


### PR DESCRIPTION

* Create an ace editor instance for entering custom code
* Users can clear contents of editor
* When a user chooses items that should be scored, the code in the custom scoring logic is not evaluated
* The string in the ace editor context is evaluated using the `Function` constructor and not `eval` to avoid the inherent security risks associated with `eval`

Refs Tangerine-Community/Tangerine#3416