### PR TITLE
fix(scoring-section): Inputs previously selected are lost

### DIFF
--- a/tangy-form-item-editor.js
+++ b/tangy-form-item-editor.js
@@ -400,7 +400,7 @@ class TangyFormItemEditor extends PolymerElement {
       items.forEach(item => {
         let isItemChecked = false;
         if(this.item.scoringSection){
-          isItemChecked = [...this.item.scoringFields].find(e=>e===item.name)
+          isItemChecked = String(this.item.scoringFields).split(',').includes(item.name)
         }
         const toggleEl = `<paper-toggle-button id="${item.name}" ${isItemChecked?'checked':''}>${item.label}</paper-toggle-button>\n`
         scoringSectionItems = scoringSectionItems + toggleEl


### PR DESCRIPTION
When the array is saved into the DB, it is usually converted into a list of comma separated values.

Always ensure the array is treated as a string then reconverted to string to allow finding items
Refs Tangerine-Community/Tangerine#3414