### PR TITLE
feat(widget): add audio recording and playing widgets

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -683,6 +683,12 @@
                     </template>
                 </tangy-form-item>
 
+                <tangy-form-item id="audio-playback" title="Audio Playback">
+                  <template>
+                    <tangy-audio-playback label="This is text" name="audio_playback" src="../demo/assets/sounds/1.mp3"></tangy-audio-playback>
+                  </template>
+                </tangy-form-item>
+
               </tangy-form>
 
             </template>

--- a/demo/index.html
+++ b/demo/index.html
@@ -685,7 +685,13 @@
 
                 <tangy-form-item id="audio-playback" title="Audio Playback">
                   <template>
-                    <tangy-audio-playback label="This is text" name="audio_playback" src="../demo/assets/sounds/1.mp3"></tangy-audio-playback>
+                    <tangy-audio-playback label="This is text" name="test-playback" src="../demo/assets/sounds/1.mp3"></tangy-audio-playback>
+                  </template>
+                </tangy-form-item>
+
+                <tangy-form-item id="audio-recording" title="Audio Recording">
+                  <template>
+                    <tangy-audio-recording name="test_recording" label="Record Audio"></tangy-audio-recording>
                   </template>
                 </tangy-form-item>
 

--- a/tangy-form-condensed-editor.js
+++ b/tangy-form-condensed-editor.js
@@ -33,6 +33,7 @@ import './widget/tangy-toggle-widget.js'
 import './widget/tangy-photo-capture-widget'
 import './widget/tangy-video-capture-widget'
 import './widget/tangy-audio-playback-widget.js'
+import './widget/tangy-audio-recording-widget.js'
 
 /**
  * `tangy-form-item-editor`

--- a/tangy-form-condensed-editor.js
+++ b/tangy-form-condensed-editor.js
@@ -32,6 +32,7 @@ import './widget/tangy-signature-widget.js'
 import './widget/tangy-toggle-widget.js'
 import './widget/tangy-photo-capture-widget'
 import './widget/tangy-video-capture-widget'
+import './widget/tangy-audio-playback-widget.js'
 
 /**
  * `tangy-form-item-editor`

--- a/tangy-form-editor-add-input.js
+++ b/tangy-form-editor-add-input.js
@@ -110,6 +110,8 @@ class TangyFormEditorAddInput extends PolymerElement {
             <mwc-button icon="grid_on"on-click="addThis" id="tangy-untimed-grid-widget" >Untimed Grid</mwc-button><br>
             <mwc-button icon="fence" on-click="addThis" id="tangy-gate-widget" >Conditional Gate</mwc-button><br>
             <mwc-button icon="auto_read_play" on-click="addThis" id="tangy-prompt-box-widget">Prompt Box</mwc-button><br>
+            <mwc-button icon="settings_voice" on-click="addThis" id="tangy-audio-recording-widget">Audio Recording</mwc-button><br>
+            <mwc-button icon="play_arrow" on-click="addThis" id="tangy-audio-playback-widget">Audio Playback</mwc-button><br>
           </div>
         </div>
       </div>

--- a/tangy-form-editor.js
+++ b/tangy-form-editor.js
@@ -36,6 +36,7 @@ import "tangy-form/input/tangy-qr.js";
 import "tangy-form/input/tangy-gate.js";
 import "tangy-form/input/tangy-consent.js";
 import "tangy-form/input/tangy-signature.js";
+import "tangy-form/input/tangy-audio-playback.js";
 
 /**
  * `tangy-form-editor`

--- a/tangy-form-editor.js
+++ b/tangy-form-editor.js
@@ -37,6 +37,7 @@ import "tangy-form/input/tangy-gate.js";
 import "tangy-form/input/tangy-consent.js";
 import "tangy-form/input/tangy-signature.js";
 import "tangy-form/input/tangy-audio-playback.js";
+import "tangy-form/input/tangy-audio-recording.js";
 
 /**
  * `tangy-form-editor`

--- a/widget/tangy-audio-playback-widget.js
+++ b/widget/tangy-audio-playback-widget.js
@@ -1,0 +1,140 @@
+import "@polymer/paper-card/paper-card.js";
+import "@polymer/paper-button/paper-button.js";
+import "tangy-form/input/tangy-audio-playback.js";
+import "tangy-form/input/tangy-checkbox.js";
+import { TangyBaseWidget } from "../tangy-base-widget.js";
+
+class TangyAudioPlaybackWidget extends TangyBaseWidget {
+  get claimElement() {
+    return "tangy-audio-playback";
+  }
+
+  get defaultConfig() {
+    return {
+      ...this.defaultConfigCoreAttributes(),
+      ...this.defaultConfigQuestionAttributes(),
+      ...this.defaultConfigConditionalAttributes(),
+      ...this.defaultConfigValidationAttributes(),
+      ...this.defaultConfigAdvancedAttributes(),
+      ...this.defaultConfigUnimplementedAttributes(),
+      src: "",
+      controls: true,
+    };
+  }
+
+  upcast(config, element) {
+    return {
+      ...this.upcastCoreAttributes(config, element),
+      ...this.upcastQuestionAttributes(config, element),
+      ...this.upcastConditionalAttributes(config, element),
+      ...this.upcastValidationAttributes(config, element),
+      ...this.upcastAdvancedAttributes(config, element),
+      ...this.upcastUnimplementedAttributes(config, element),
+      ...element.getProps(),
+      hideOutput: element.hasAttribute("controls"),
+    };
+  }
+
+  downcast(config) {
+    return `
+      <tangy-audio-playback 
+        ${this.downcastCoreAttributes(config)}
+        ${this.downcastQuestionAttributes(config)}
+        ${this.downcastConditionalAttributes(config)}
+        ${this.downcastValidationAttributes(config)}
+        ${this.downcastAdvancedAttributes(config)}
+        ${this.downcastUnimplementedAttributes(config)}
+        ${config.controls ? "controls" : ""}
+        ${config.src ? `src="${config.src}"` : ""}
+      >
+      </tangy-audio-playback>
+    `;
+  }
+
+  renderPrint(config) {
+    return `
+    <table>
+      <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+      <tr><td><strong>Audio Source:</strong></td><td>${config.src}</td></tr>
+      <tr><td><strong>Controls:</strong></td><td>${config.controls}</td></tr>
+    </table>
+    <hr/>
+    `;
+  }
+
+  renderInfo(config) {
+    const icon = (this.shadowRoot.querySelector(
+      "#icon"
+    ).innerHTML = `<span class="header-text"><mwc-icon>play_arrow</mwc-icon><span>`);
+    const name = (this.shadowRoot.querySelector(
+      "#name"
+    ).innerHTML = `<span class="header-text">${config.name}</span>`);
+    return `${icon} ${name} ${this.downcast(config)}`;
+  }
+
+  renderEdit(config) {
+    const action = config.name ? "Edit" : "Add";
+    return `
+      <h2>${action} Audio Playback</h2>
+      <tangy-form id="tangy-audio-playback">
+        <tangy-form-item>
+          <template>
+            <paper-tabs selected="0">
+                <paper-tab>Question</paper-tab>
+                <paper-tab>Conditional Display</paper-tab>
+                <paper-tab>Validation</paper-tab>
+                <paper-tab>Advanced</paper-tab>
+            </paper-tabs>
+            <iron-pages selected="">
+              <div>
+                  ${this.renderEditCoreAttributes(config)}
+                  ${this.renderEditQuestionAttributes(config)}
+                  <tangy-input name="src" type="string" inner-label="Audio Source." value="${
+                    config.src
+                  }"></tangy-input>
+                  <tangy-toggle name="controls" help-text="Show Audio Playback Controls? (default: true)"
+                      ${config.controls ? 'value="on"' : ''}>Show Audio Playback Controls?
+                  </tangy-toggle>
+              </div>
+              <div>
+                ${this.renderEditConditionalAttributes(config)}
+              </div>
+              <div>
+                ${this.renderEditValidationAttributes(config)}
+              </div>
+              <div>
+                ${this.renderEditAdvancedAttributes(config)}
+              </div>
+            </iron-pages>
+          </template>
+        </tangy-form-item>
+      </tangy-form>
+    `;
+  }
+
+  onSubmit(config, formEl) {
+    return {
+      ...this.onSubmitCoreAttributes(config, formEl),
+      ...this.onSubmitQuestionAttributes(config, formEl),
+      ...this.onSubmitConditionalAttributes(config, formEl),
+      ...this.onSubmitValidationAttributes(config, formEl),
+      ...this.onSubmitAdvancedAttributes(config, formEl),
+      ...this.onSubmitUnimplementedAttributes(config, formEl),
+      src:  formEl.values["src"],
+      controls: !!formEl.inputs.find(e=>e.name==='controls').value,
+    };
+  }
+}
+
+window.customElements.define(
+  "tangy-audio-playback-widget",
+  TangyAudioPlaybackWidget
+);
+window.tangyFormEditorWidgets.define(
+  "tangy-audio-playback-widget",
+  "tangy-audio-playback",
+  TangyAudioPlaybackWidget
+);

--- a/widget/tangy-audio-recording-widget.js
+++ b/widget/tangy-audio-recording-widget.js
@@ -1,0 +1,126 @@
+import "@polymer/paper-card/paper-card.js";
+import "@polymer/paper-button/paper-button.js";
+import "tangy-form/input/tangy-audio-recording.js";
+import "tangy-form/input/tangy-checkbox.js";
+import { TangyBaseWidget } from "../tangy-base-widget.js";
+
+class TangyAudioRecordingWidget extends TangyBaseWidget {
+  get claimElement() {
+    return "tangy-audio-recording";
+  }
+
+  get defaultConfig() {
+    return {
+      ...this.defaultConfigCoreAttributes(),
+      ...this.defaultConfigQuestionAttributes(),
+      ...this.defaultConfigConditionalAttributes(),
+      ...this.defaultConfigValidationAttributes(),
+      ...this.defaultConfigAdvancedAttributes(),
+      ...this.defaultConfigUnimplementedAttributes(),
+      
+    };
+  }
+
+  upcast(config, element) {
+    return {
+      ...this.upcastCoreAttributes(config, element),
+      ...this.upcastQuestionAttributes(config, element),
+      ...this.upcastConditionalAttributes(config, element),
+      ...this.upcastValidationAttributes(config, element),
+      ...this.upcastAdvancedAttributes(config, element),
+      ...this.upcastUnimplementedAttributes(config, element),
+      ...element.getProps()
+    };
+  }
+
+  downcast(config) {
+    return `
+      <tangy-audio-recording 
+        ${this.downcastCoreAttributes(config)}
+        ${this.downcastQuestionAttributes(config)}
+        ${this.downcastConditionalAttributes(config)}
+        ${this.downcastValidationAttributes(config)}
+        ${this.downcastAdvancedAttributes(config)}
+        ${this.downcastUnimplementedAttributes(config)}
+      >
+      </tangy-audio-recording>
+    `;
+  }
+
+  renderPrint(config) {
+    return `
+    <table>
+      <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
+      <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
+      <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
+    </table>
+    <hr/>
+    `;
+  }
+
+  renderInfo(config) {
+    console.log(config)
+    const icon = (this.shadowRoot.querySelector(
+      "#icon"
+    ).innerHTML = `<span class="header-text"><mwc-icon>settings_voice</mwc-icon><span>`);
+    const name = (this.shadowRoot.querySelector(
+      "#name"
+    ).innerHTML = `<span class="header-text">${config.name}</span>`);
+    return `${icon} ${name} ${this.downcast(config)}`;
+  }
+
+  renderEdit(config) {
+    console.log(config)
+    const action = config.name ? "Edit" : "Add";
+    return `
+      <h2>${action} Audio Recording</h2>
+      
+      <tangy-form id="tangy-audio-recording">
+        <tangy-form-item>
+          <template>
+            <paper-tabs selected="0">
+                <paper-tab>General</paper-tab>
+                <paper-tab>Conditional Display</paper-tab>
+                <paper-tab>Validation</paper-tab>
+                <paper-tab>Advanced</paper-tab>
+            </paper-tabs>
+            <iron-pages selected="">
+                <div>
+                  ${this.renderEditCoreAttributes(config)}
+                  ${this.renderEditQuestionAttributes(config)}
+                </div>
+                <div>
+                  ${this.renderEditConditionalAttributes(config)}
+                </div>
+                <div>
+                  ${this.renderEditValidationAttributes(config)}
+                </div>
+                <div>
+                  ${this.renderEditAdvancedAttributes(config)}
+                </div>
+            </iron-pages>
+          </template>
+        </tangy-form-item>
+      </tangy-form>
+    `;
+  }
+
+  onSubmit(config, formEl) {
+    return {
+      ...this.onSubmitCoreAttributes(config, formEl),
+      ...this.onSubmitQuestionAttributes(config, formEl),
+      ...this.onSubmitConditionalAttributes(config, formEl),
+      ...this.onSubmitValidationAttributes(config, formEl),
+      ...this.onSubmitAdvancedAttributes(config, formEl),
+      ...this.onSubmitUnimplementedAttributes(config, formEl),
+    };
+  }
+}
+
+window.customElements.define("tangy-audio-recording-widget", TangyAudioRecordingWidget);
+window.tangyFormEditorWidgets.define(
+  "tangy-audio-recording-widget",
+  "tangy-audio-recording",
+  TangyAudioRecordingWidget
+);


### PR DESCRIPTION
Added a new widget for audio playback functionality. This includes:
- New tangy-audio-playback-widget.js file
- Integration of the widget in demo/index.html
- Import statements in tangy-form-condensed-editor.js and tangy-form-editor.js

Refs Tangerine-Community/tangy-form#418
- Added a new widget `tangy-audio-recording-widget.js` to support audio recording functionality.
- Updated `demo/index.html` to include the new audio recording widget.
- Modified `tangy-form-condensed-editor.js` and `tangy-form-editor.js` to import the new widget.

Refs https://github.com/Tangerine-Community/tangy-form/issues/419