### PR TITLE
Min duration audio rec in interface 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v7.22.6
+
+- Bump tangy-form to 4.50.8 - add min-duration to tangy-audio-recording
+- Fix tangy-radio-blocks saving Column layout and not preserving Rows if already set
+
 ## v7.22.0, v7.22.1, v7.22.2, v7.22.3, v7.22.4, v7.22.5
 
 - Add tangy-audio-recording-nlp-widget

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tangy-form-editor",
-  "version": "7.22.5",
+  "version": "7.22.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tangy-form-editor",
-  "version": "7.22.6",
+  "version": "7.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tangy-form-editor",
-  "version": "7.23.0",
+  "version": "7.22.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tangy-form-editor",
-  "version": "7.22.6",
+  "version": "7.22.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18281,7 +18281,7 @@
       "dev": true
     },
     "tangy-form": {
-      "version": "4.50.6",
+      "version": "4.50.8",
       "resolved": "https://registry.npmjs.org/tangy-form/-/tangy-form-4.50.6.tgz",
       "integrity": "sha512-ODzAWkj1b+cxpp+YkTZpMSBZ9nXi+zfn3okoefF0DGOpkYWq/5LzuMaQOEhFHW21NbSbNZSg0/ym31zjXaPMgg==",
       "requires": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "js-beautify": "^1.14.7",
     "juicy-ace-editor": "https://github.com/Juicy/juicy-ace-editor.git#ES6-modules",
     "redux": "^4.2.0",
-    "tangy-form": "^4.50.6",
+    "tangy-form": "^4.50.8",
     "tangy-translate": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tangy-form-editor",
   "main": "tangy-form-editor.js",
-  "version": "7.22.6",
+  "version": "7.23.0",
   "scripts": {
     "start": "./node_modules/.bin/polymer serve",
     "build": "webpack",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tangy-form-editor",
   "main": "tangy-form-editor.js",
-  "version": "7.22.6",
+  "version": "7.22.5",
   "scripts": {
     "start": "./node_modules/.bin/polymer serve",
     "build": "webpack",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tangy-form-editor",
   "main": "tangy-form-editor.js",
-  "version": "7.23.0",
+  "version": "7.22.6",
   "scripts": {
     "start": "./node_modules/.bin/polymer serve",
     "build": "webpack",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tangy-form-editor",
   "main": "tangy-form-editor.js",
-  "version": "7.22.5",
+  "version": "7.22.6",
   "scripts": {
     "start": "./node_modules/.bin/polymer serve",
     "build": "webpack",

--- a/widget/tangy-audio-recording-widget.js
+++ b/widget/tangy-audio-recording-widget.js
@@ -17,7 +17,7 @@ class TangyAudioRecordingWidget extends TangyBaseWidget {
       ...this.defaultConfigValidationAttributes(),
       ...this.defaultConfigAdvancedAttributes(),
       ...this.defaultConfigUnimplementedAttributes(),
-      
+      minDuration: 5 // Default value for new questions
     };
   }
 
@@ -29,11 +29,15 @@ class TangyAudioRecordingWidget extends TangyBaseWidget {
       ...this.upcastValidationAttributes(config, element),
       ...this.upcastAdvancedAttributes(config, element),
       ...this.upcastUnimplementedAttributes(config, element),
-      ...element.getProps()
+      ...element.getProps(),
+      // Use the attribute if it exists, otherwise fall back to the default from config
+      minDuration: element.hasAttribute("min-duration") ? element.getAttribute("min-duration") : ''
     };
   }
 
   downcast(config) {
+    const minDurationAttr = (config.minDuration !== '' && config.minDuration !== undefined) ? `min-duration="${config.minDuration}"` : '';
+
     return `
       <tangy-audio-recording 
         ${this.downcastCoreAttributes(config)}
@@ -42,6 +46,7 @@ class TangyAudioRecordingWidget extends TangyBaseWidget {
         ${this.downcastValidationAttributes(config)}
         ${this.downcastAdvancedAttributes(config)}
         ${this.downcastUnimplementedAttributes(config)}
+        ${minDurationAttr}
       >
       </tangy-audio-recording>
     `;
@@ -52,6 +57,7 @@ class TangyAudioRecordingWidget extends TangyBaseWidget {
     <table>
       <tr><td><strong>Variable Name:</strong></td><td>${config.name}</td></tr>
       <tr><td><strong>Required:</strong></td><td>${config.required}</td></tr>
+      <tr><td><strong>Min Duration:</strong></td><td>${config.minDuration}s</td></tr>
       <tr><td><strong>Disabled:</strong></td><td>${config.disabled}</td></tr>
       <tr><td><strong>Hidden:</strong></td><td>${config.hidden}</td></tr>
     </table>
@@ -83,10 +89,16 @@ class TangyAudioRecordingWidget extends TangyBaseWidget {
                 <paper-tab>Validation</paper-tab>
                 <paper-tab>Advanced</paper-tab>
             </paper-tabs>
-            <iron-pages selected="">
+            <iron-pages selected="0">
                 <div>
                   ${this.renderEditCoreAttributes(config)}
                   ${this.renderEditQuestionAttributes(config)}
+                  <tangy-input 
+                    name="minDuration" 
+                    label="Minimum Duration (seconds)" 
+                    value="${config.minDuration}" 
+                    type="number">
+                  </tangy-input>
                 </div>
                 <div>
                   ${this.renderEditConditionalAttributes(config)}
@@ -105,6 +117,8 @@ class TangyAudioRecordingWidget extends TangyBaseWidget {
   }
 
   onSubmit(config, formEl) {
+    const minDurInput = formEl.querySelector('tangy-input[name="minDuration"]').value;
+
     return {
       ...this.onSubmitCoreAttributes(config, formEl),
       ...this.onSubmitQuestionAttributes(config, formEl),
@@ -112,6 +126,7 @@ class TangyAudioRecordingWidget extends TangyBaseWidget {
       ...this.onSubmitValidationAttributes(config, formEl),
       ...this.onSubmitAdvancedAttributes(config, formEl),
       ...this.onSubmitUnimplementedAttributes(config, formEl),
+      minDuration: (minDurInput !== '' && !isNaN(minDurInput)) ? parseInt(minDurInput) : ''
     };
   }
 }

--- a/widget/tangy-radio-blocks-widget.js
+++ b/widget/tangy-radio-blocks-widget.js
@@ -19,6 +19,7 @@ class TangyRadioBlocksWidget extends TangyBaseWidget {
       ...this.defaultConfigValidationAttributes(),
       ...this.defaultConfigAdvancedAttributes(),
       ...this.defaultConfigUnimplementedAttributes(),
+      orientation: "columns",
       options: [],
     };
   }
@@ -120,10 +121,10 @@ class TangyRadioBlocksWidget extends TangyBaseWidget {
                 ${this.renderEditCoreAttributes(config)}
                 ${this.renderEditQuestionAttributes(config)}
                 <label for="orientation" style="font-weight: bold; font-size: 1.2em;">Orientation:</label>
-                <tangy-select name="orientation">
-                  <option value="columns" ${config.orientation === "columns" ? "selected" : ""}>Columns</option>
-                  <option value="rows" ${config.orientation === "rows" ? "selected" : ""}>Rows</option>
-                </tangy-select>
+                <tangy-select name="orientation" value="${config.orientation || 'columns'}">
+                  <option value="columns">Columns</option>
+                  <option value="rows">Rows</option>
+		</tangy-select>
                 <h2>Options</h2>
                 <p>Click the "Correct" property for options that are the correct answer. This property is used with the Section Detail's Threshold property.</p>
                 <tangy-list name="options">


### PR DESCRIPTION
# CHANGELOG

## v7.22.6

- Bump tangy-form to 4.50.8 - add min-duration to tangy-audio-recording
- Fix tangy-radio-blocks saving Column layout and not preserving Rows if already set